### PR TITLE
fix: open lean doc links in new browser tab (AUT-18)

### DIFF
--- a/tools/leanblueprint/leanblueprint/Packages/blueprint.py
+++ b/tools/leanblueprint/leanblueprint/Packages/blueprint.py
@@ -229,7 +229,7 @@ LEAN_DECLS_TPL = Template("""
     {% call modal('Lean declarations') %}
         <ul class="uses">
           {% for lean, url in obj.userdata.lean_urls %}
-          <li><a href="{{ url }}" class="lean_decl">{{ lean }}</a></li>
+          <li><a href="{{ url }}" class="lean_decl" target="_blank" rel="noopener">{{ lean }}</a></li>
           {% endfor %}
         </ul>
     {% endcall %}
@@ -249,12 +249,12 @@ LEAN_LINKS_TPL = Template("""
       <span class="lean_link">Lean</span>
       <ul class="tooltip_list">
         {% for name, url in thm.userdata['lean_urls'] %}
-           <li><a href="{{ url }}" class="lean_decl">{{ name }}</a></li>
+           <li><a href="{{ url }}" class="lean_decl" target="_blank" rel="noopener">{{ name }}</a></li>
         {% endfor %}
       </ul>
   </div>
     {%- else -%}
-    <a class="lean_link lean_decl" href="{{ thm.userdata['lean_urls'][0][1] }}">Lean</a>
+    <a class="lean_link lean_decl" href="{{ thm.userdata['lean_urls'][0][1] }}" target="_blank" rel="noopener">Lean</a>
     {%- endif -%}
     {%- endif -%}
 """)


### PR DESCRIPTION
## Summary
- Add `target="_blank" rel="noopener"` to all `<a class="lean_decl">` links in `LEAN_DECLS_TPL` and `LEAN_LINKS_TPL` templates
- Clicking a Lean documentation link now opens in a new tab instead of navigating away from the blueprint page

Fixes AUT-18

## Test plan
- [ ] Rebuild blueprint with `leanblueprint web`
- [ ] Click a Lean doc link in the dependency graph — should open in a new tab
- [ ] Click a Lean doc link in the theorem header — should open in a new tab
- [ ] Verify the blueprint page remains open in the original tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)