### PR TITLE
feat: add browser-based annotation system for blueprint

### DIFF
--- a/blueprint/build.sh
+++ b/blueprint/build.sh
@@ -20,8 +20,21 @@ fi
 #    leanblueprint all = mk_pdf + mk_web + lake build + checkdecls
 #    Since we already ran lake build in step 1, call subcommands directly
 #    to avoid building twice.
+# ── 2.5. Inject annotations into LaTeX source (optional) ──────────────
+ANNOTATIONS_JSON="$PROJECT_ROOT/blueprint/annotations-export.json"
+if [[ -f "$ANNOTATIONS_JSON" ]]; then
+  echo "==> Injecting annotations into LaTeX source"
+  python3 "$PROJECT_ROOT/blueprint/inject_annotations.py" "$ANNOTATIONS_JSON"
+fi
+
 echo "==> leanblueprint pdf"
 leanblueprint pdf
+
+# ── Restore LaTeX source after PDF build (undo injected annotations) ──
+if [[ -f "$ANNOTATIONS_JSON" ]]; then
+  echo "==> Restoring LaTeX source (removing injected annotations)"
+  python3 "$PROJECT_ROOT/blueprint/inject_annotations.py" --restore
+fi
 
 echo "==> leanblueprint web"
 leanblueprint web

--- a/blueprint/inject_annotations.py
+++ b/blueprint/inject_annotations.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Inject exported browser annotations into LaTeX source as margin notes.
+
+Usage:
+    python3 inject_annotations.py [annotations.json] [--output-dir DIR]
+
+Reads a JSON file exported from the blueprint annotation system and injects
+\\marginpar notes after the corresponding \\label{} commands in the .tex
+source files under blueprint/src/chapters/.
+
+Only annotations whose element-id matches a LaTeX label are injected;
+paragraph-level annotations (containing '--p') are skipped since they have
+no stable LaTeX anchor.
+"""
+
+import json
+import sys
+import os
+import re
+import glob
+import shutil
+from datetime import datetime
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+CHAPTERS_DIR = os.path.join(SCRIPT_DIR, 'src', 'chapters')
+BACKUP_SUFFIX = '.bak-annotations'
+
+
+def load_annotations(path):
+    with open(path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    return data.get('annotations', {})
+
+
+def format_comment_latex(comments):
+    """Format a list of comments as a LaTeX marginnote."""
+    parts = []
+    for c in comments:
+        author = c.get('author', 'Anonymous')
+        text = c.get('text', '')
+        resolved = c.get('resolved', False)
+        prefix = '[Resolved] ' if resolved else ''
+        safe_text = text.replace('\\', '\\textbackslash{}')
+        safe_text = safe_text.replace('{', '\\{').replace('}', '\\}')
+        safe_text = safe_text.replace('#', '\\#').replace('&', '\\&')
+        safe_text = safe_text.replace('%', '\\%').replace('$', '\\$')
+        safe_text = safe_text.replace('_', '\\_')
+        safe_author = author.replace('_', '\\_')
+        parts.append(
+            f'\\textbf{{{safe_author}}}: {prefix}{safe_text}'
+        )
+    joined = ' \\\\[2pt] '.join(parts)
+    return (
+        f'\\marginpar{{\\footnotesize\\raggedright '
+        f'\\textcolor{{orange}}{{\\textbf{{Comment}}}} \\\\ {joined}}}'
+    )
+
+
+def inject_into_file(tex_path, annotations):
+    """Inject annotations into a single .tex file. Returns number injected."""
+    with open(tex_path, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    injected = 0
+    for el_id, comments in annotations.items():
+        if '--p' in el_id:
+            continue
+        label_pattern = r'(\\label\{' + re.escape(el_id) + r'\})'
+        match = re.search(label_pattern, content)
+        if not match:
+            continue
+        note = format_comment_latex(comments)
+        insertion = match.group(0) + '\n' + note
+        content = content[:match.start()] + insertion + content[match.end():]
+        injected += 1
+
+    if injected > 0:
+        backup = tex_path + BACKUP_SUFFIX
+        if not os.path.exists(backup):
+            shutil.copy2(tex_path, backup)
+        with open(tex_path, 'w', encoding='utf-8') as f:
+            f.write(content)
+
+    return injected
+
+
+def restore_backups():
+    """Remove injected annotations by restoring .bak files."""
+    for bak in glob.glob(os.path.join(CHAPTERS_DIR, '*' + BACKUP_SUFFIX)):
+        original = bak[:-len(BACKUP_SUFFIX)]
+        shutil.move(bak, original)
+        print(f'  Restored {os.path.basename(original)}')
+
+
+def main():
+    if len(sys.argv) < 2:
+        json_path = os.path.join(SCRIPT_DIR, 'annotations-export.json')
+    else:
+        if sys.argv[1] == '--restore':
+            print('Restoring backups...')
+            restore_backups()
+            return
+        json_path = sys.argv[1]
+
+    if not os.path.exists(json_path):
+        print(f'No annotation file found at {json_path}, skipping injection.')
+        return
+
+    annotations = load_annotations(json_path)
+    if not annotations:
+        print('No annotations to inject.')
+        return
+
+    print(f'Loaded {sum(len(v) for v in annotations.values())} comment(s) '
+          f'for {len(annotations)} element(s)')
+
+    tex_files = glob.glob(os.path.join(CHAPTERS_DIR, '*.tex'))
+    total = 0
+    for tf in tex_files:
+        n = inject_into_file(tf, annotations)
+        if n > 0:
+            print(f'  Injected {n} annotation(s) into {os.path.basename(tf)}')
+            total += n
+
+    print(f'Total: {total} annotation(s) injected.')
+    if total > 0:
+        print('Run "python3 inject_annotations.py --restore" to undo.')
+
+
+if __name__ == '__main__':
+    main()

--- a/blueprint/src/annotations.css
+++ b/blueprint/src/annotations.css
@@ -1,0 +1,344 @@
+/* ── Annotation / Comment System ── */
+
+/* Indicator icon on each annotatable element */
+.annotation-indicator {
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  color: #E69F00;
+  background: rgba(230, 159, 0, 0.08);
+  border: 1px solid rgba(230, 159, 0, 0.3);
+  transition: color 0.2s, background 0.2s, border-color 0.2s;
+  user-select: none;
+  vertical-align: middle;
+  margin-left: 6px;
+}
+.annotation-indicator:hover {
+  color: #E69F00;
+  background: rgba(230, 159, 0, 0.1);
+}
+.annotation-indicator.has-comments {
+  color: #E69F00;
+  font-weight: bold;
+}
+.annotation-indicator .ann-icon {
+  font-size: 1rem;
+  margin-right: 2px;
+  line-height: 1;
+}
+.annotation-indicator .ann-count {
+  font-size: 0.75rem;
+  min-width: 14px;
+  text-align: center;
+}
+
+/* Paragraph-level indicator (absolutely positioned) */
+.ann-indicator-float {
+  position: absolute;
+  top: 2px;
+  right: -30px;
+  z-index: 10;
+}
+
+/* Highlight for elements that have annotations */
+.has-annotations {
+  border-left: 3px solid #E69F00 !important;
+}
+
+/* ── Annotation panel ── */
+.annotation-panel {
+  display: none;
+  background: #f8f9fa;
+  border: 1px solid #ddd;
+  border-left: 3px solid #E69F00;
+  border-radius: 4px;
+  margin: 8px 0 12px 0;
+  padding: 10px 14px;
+  font-size: 0.88rem;
+  line-height: 1.5;
+}
+.annotation-panel.open {
+  display: block;
+}
+
+/* Panel header */
+.ann-panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid #e0e0e0;
+}
+.ann-panel-title {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: #333;
+}
+.ann-panel-close {
+  cursor: pointer;
+  font-size: 1.1rem;
+  color: #999;
+  background: none;
+  border: none;
+  padding: 0 4px;
+}
+.ann-panel-close:hover {
+  color: #333;
+}
+
+/* Comment list */
+.ann-comments-list {
+  max-height: 300px;
+  overflow-y: auto;
+  margin-bottom: 10px;
+}
+.ann-entry {
+  padding: 8px 10px;
+  margin-bottom: 6px;
+  background: #fff;
+  border: 1px solid #eee;
+  border-radius: 3px;
+}
+.ann-entry.resolved {
+  opacity: 0.55;
+  background: #f0f0f0;
+}
+.ann-entry-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 4px;
+}
+.ann-author {
+  font-weight: 600;
+  font-size: 0.8rem;
+  color: #555;
+}
+.ann-time {
+  font-size: 0.72rem;
+  color: #999;
+}
+.ann-text {
+  color: #333;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.ann-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 6px;
+}
+.ann-actions button {
+  font-size: 0.72rem;
+  padding: 1px 6px;
+  border: 1px solid #ccc;
+  border-radius: 2px;
+  background: #fff;
+  color: #666;
+  cursor: pointer;
+}
+.ann-actions button:hover {
+  background: #eee;
+  color: #333;
+}
+.ann-actions .ann-resolve-btn.is-resolved {
+  color: #28a745;
+  border-color: #28a745;
+}
+
+/* Empty state */
+.ann-empty {
+  color: #999;
+  font-style: italic;
+  font-size: 0.82rem;
+  padding: 6px 0;
+}
+
+/* Input area */
+.ann-input-area {
+  border-top: 1px solid #e0e0e0;
+  padding-top: 8px;
+}
+.ann-input-row {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 6px;
+  align-items: center;
+}
+.ann-input-row label {
+  font-size: 0.78rem;
+  color: #666;
+  min-width: 40px;
+}
+.ann-author-input {
+  flex: 1;
+  padding: 3px 8px;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  font-size: 0.82rem;
+}
+.ann-text-input {
+  width: 100%;
+  min-height: 50px;
+  padding: 6px 8px;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  font-size: 0.84rem;
+  font-family: inherit;
+  resize: vertical;
+  box-sizing: border-box;
+}
+.ann-submit-btn {
+  padding: 4px 14px;
+  background: #E69F00;
+  color: #fff;
+  border: none;
+  border-radius: 3px;
+  font-size: 0.82rem;
+  cursor: pointer;
+  float: right;
+}
+.ann-submit-btn:hover {
+  background: #cc8c00;
+}
+
+/* Edit mode */
+.ann-edit-textarea {
+  width: 100%;
+  min-height: 40px;
+  padding: 4px 6px;
+  border: 1px solid #E69F00;
+  border-radius: 3px;
+  font-size: 0.84rem;
+  font-family: inherit;
+  resize: vertical;
+  box-sizing: border-box;
+}
+.ann-edit-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 4px;
+}
+.ann-edit-actions button {
+  font-size: 0.75rem;
+  padding: 2px 10px;
+  border-radius: 2px;
+  cursor: pointer;
+}
+.ann-save-btn {
+  background: #E69F00;
+  color: #fff;
+  border: 1px solid #E69F00;
+}
+.ann-cancel-btn {
+  background: #fff;
+  color: #666;
+  border: 1px solid #ccc;
+}
+
+/* ── Floating toolbar ── */
+#annotation-toolbar {
+  position: fixed;
+  bottom: 1.2rem;
+  right: 1.2rem;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+}
+#annotation-toolbar .ann-toolbar-main {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  padding: 6px 12px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+  font-size: 0.82rem;
+}
+#annotation-toolbar .ann-toolbar-badge {
+  background: #E69F00;
+  color: #fff;
+  font-size: 0.72rem;
+  font-weight: 700;
+  padding: 1px 6px;
+  border-radius: 10px;
+  min-width: 18px;
+  text-align: center;
+}
+#annotation-toolbar button {
+  padding: 4px 10px;
+  font-size: 0.78rem;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  background: #fff;
+  color: #555;
+  cursor: pointer;
+}
+#annotation-toolbar button:hover {
+  background: #f0f0f0;
+}
+.ann-toolbar-options {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.78rem;
+  color: #666;
+}
+.ann-toolbar-options input[type="checkbox"] {
+  margin: 0;
+}
+
+/* ── Print styles ── */
+@media print {
+  /* Hide interactive controls */
+  .annotation-indicator,
+  #annotation-toolbar,
+  .ann-actions,
+  .ann-input-area,
+  .ann-panel-close,
+  .ann-edit-actions {
+    display: none !important;
+  }
+
+  /* Show annotation panels that have comments */
+  .annotation-panel.has-print-comments {
+    display: block !important;
+    border: 1px solid #999;
+    border-left: 3px solid #E69F00;
+    page-break-inside: avoid;
+    background: #fafafa;
+    box-shadow: none;
+  }
+
+  /* Show resolved comments in print */
+  .ann-entry.resolved {
+    opacity: 1 !important;
+    display: block !important;
+  }
+
+  /* Print label for comment section */
+  .ann-print-label {
+    display: block;
+    font-weight: 700;
+    font-size: 0.8rem;
+    color: #666;
+    margin-bottom: 4px;
+  }
+
+  /* Hide in screen */
+  @media screen {
+    .ann-print-label { display: none; }
+  }
+}
+
+/* Screen-only: hide print label */
+@media screen {
+  .ann-print-label { display: none; }
+}

--- a/blueprint/src/annotations.js
+++ b/blueprint/src/annotations.js
@@ -1,0 +1,582 @@
+/* Blueprint Annotation System — localStorage-based comments for blueprint pages */
+(function($) {
+  'use strict';
+
+  var STORAGE_KEY = 'blueprint_annotations';
+  var AUTHOR_KEY = 'blueprint_annotations_author';
+
+  var ANNOTATABLE_SELECTORS = [
+    '[class$="_thmwrapper"]',
+    '.proof_wrapper',
+    '.main-text > p',
+    '[class$="_thmcontent"] > p'
+  ];
+
+  // ── AnnotationStore ──
+
+  var AnnotationStore = {
+    _data: null,
+
+    load: function() {
+      if (this._data) return this._data;
+      try {
+        var raw = localStorage.getItem(STORAGE_KEY);
+        this._data = raw ? JSON.parse(raw) : { version: 1, annotations: {} };
+      } catch(e) {
+        this._data = { version: 1, annotations: {} };
+      }
+      return this._data;
+    },
+
+    save: function() {
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(this._data));
+      } catch(e) { /* quota exceeded — silent */ }
+    },
+
+    getForElement: function(elId) {
+      var data = this.load();
+      return (data.annotations[elId] || []).slice();
+    },
+
+    countForElement: function(elId) {
+      var data = this.load();
+      return (data.annotations[elId] || []).length;
+    },
+
+    totalCount: function() {
+      var data = this.load();
+      var n = 0;
+      for (var k in data.annotations) n += data.annotations[k].length;
+      return n;
+    },
+
+    addComment: function(elId, text, author) {
+      var data = this.load();
+      if (!data.annotations[elId]) data.annotations[elId] = [];
+      var comment = {
+        id: 'ann_' + this._uuid(),
+        text: text,
+        author: author || 'Anonymous',
+        created: new Date().toISOString(),
+        modified: null,
+        resolved: false
+      };
+      data.annotations[elId].push(comment);
+      this.save();
+      return comment;
+    },
+
+    editComment: function(elId, commentId, newText) {
+      var list = this.load().annotations[elId] || [];
+      for (var i = 0; i < list.length; i++) {
+        if (list[i].id === commentId) {
+          list[i].text = newText;
+          list[i].modified = new Date().toISOString();
+          this.save();
+          return list[i];
+        }
+      }
+      return null;
+    },
+
+    deleteComment: function(elId, commentId) {
+      var data = this.load();
+      var list = data.annotations[elId] || [];
+      data.annotations[elId] = list.filter(function(c) { return c.id !== commentId; });
+      if (data.annotations[elId].length === 0) delete data.annotations[elId];
+      this.save();
+    },
+
+    toggleResolved: function(elId, commentId) {
+      var list = this.load().annotations[elId] || [];
+      for (var i = 0; i < list.length; i++) {
+        if (list[i].id === commentId) {
+          list[i].resolved = !list[i].resolved;
+          this.save();
+          return list[i];
+        }
+      }
+      return null;
+    },
+
+    exportJSON: function() {
+      var data = this.load();
+      var enriched = { version: data.version, annotations: {} };
+      for (var elId in data.annotations) {
+        var $el = $('[data-annotation-id="' + elId + '"]');
+        var context = _buildContext($el, elId);
+        enriched.annotations[elId] = {
+          context: context,
+          comments: data.annotations[elId]
+        };
+      }
+      return JSON.stringify(enriched, null, 2);
+    },
+
+    importJSON: function(jsonStr) {
+      try {
+        var incoming = JSON.parse(jsonStr);
+        if (!incoming.annotations) return { added: 0, error: null };
+        var data = this.load();
+        var added = 0;
+        for (var elId in incoming.annotations) {
+          var entry = incoming.annotations[elId];
+          var comments = Array.isArray(entry) ? entry : (entry.comments || []);
+          if (!data.annotations[elId]) data.annotations[elId] = [];
+          var existing = {};
+          data.annotations[elId].forEach(function(c) { existing[c.id] = true; });
+          comments.forEach(function(c) {
+            if (!existing[c.id]) {
+              data.annotations[elId].push(c);
+              added++;
+            }
+          });
+        }
+        this.save();
+        return { added: added, error: null };
+      } catch(e) {
+        return { added: 0, error: e.message };
+      }
+    },
+
+    _uuid: function() {
+      return 'xxxx-xxxx'.replace(/x/g, function() {
+        return (Math.random() * 16 | 0).toString(16);
+      }) + '-' + Date.now().toString(36);
+    }
+  };
+
+  function _buildContext($el, elId) {
+    var ctx = { id: elId, page: window.location.pathname.split('/').pop() || 'index.html' };
+
+    if (!$el.length) return ctx;
+
+    var wrapper = $el.closest('[class$="_thmwrapper"]');
+    if (wrapper.length) {
+      var caption = wrapper.find('[class$="_thmcaption"]').first().text().trim();
+      var label = wrapper.find('[class$="_thmlabel"]').first().text().trim();
+      ctx.type = caption || 'Statement';
+      ctx.label = label;
+      ctx.title = (caption && label) ? caption + ' ' + label : (caption || label || '');
+      var content = wrapper.find('[class$="_thmcontent"]').first().text().trim();
+      ctx.excerpt = content.substring(0, 120).replace(/\s+/g, ' ');
+      if (content.length > 120) ctx.excerpt += '...';
+      return ctx;
+    }
+
+    if ($el.hasClass('proof_wrapper')) {
+      ctx.type = 'Proof';
+      var prev = $el.prev('[class$="_thmwrapper"]');
+      if (prev.length) {
+        var pc = prev.find('[class$="_thmcaption"]').first().text().trim();
+        var pl = prev.find('[class$="_thmlabel"]').first().text().trim();
+        ctx.title = 'Proof of ' + ((pc && pl) ? pc + ' ' + pl : (pc || pl || ''));
+      }
+      return ctx;
+    }
+
+    ctx.type = 'Paragraph';
+    var text = $el.text().trim();
+    ctx.excerpt = text.substring(0, 120).replace(/\s+/g, ' ');
+    if (text.length > 120) ctx.excerpt += '...';
+
+    var section = $el.closest('[id^="sec:"]');
+    if (section.length) {
+      ctx.section = section.find('h1,h2,h3,h4').first().text().trim() || section.attr('id');
+    }
+    return ctx;
+  }
+
+  // ── Stable ID assignment ──
+
+  function getPageName() {
+    var path = window.location.pathname;
+    var parts = path.split('/');
+    var file = parts[parts.length - 1] || 'index';
+    return file.replace(/\.html$/, '');
+  }
+
+  function findNearestIdAncestor(el) {
+    var node = el.parentElement;
+    while (node) {
+      if (node.id) return node.id;
+      node = node.parentElement;
+    }
+    return 'root';
+  }
+
+  function assignAnnotationIds() {
+    var page = getPageName();
+    $(ANNOTATABLE_SELECTORS.join(',')).each(function() {
+      var el = this;
+      if (el.id) {
+        el.setAttribute('data-annotation-id', el.id);
+      } else {
+        var ancestor = findNearestIdAncestor(el);
+        var siblings = $(el).parent().children(el.tagName);
+        var idx = siblings.index(el);
+        var genId = page + '--' + ancestor + '--p' + idx;
+        el.setAttribute('data-annotation-id', genId);
+      }
+    });
+  }
+
+  // ── Author helpers ──
+
+  function getAuthor() {
+    return localStorage.getItem(AUTHOR_KEY) || '';
+  }
+
+  function setAuthor(name) {
+    localStorage.setItem(AUTHOR_KEY, name);
+  }
+
+  // ── UI rendering ──
+
+  var showResolved = false;
+
+  function createIndicator(annId, count) {
+    var $ind = $('<span class="annotation-indicator" data-for="' + annId + '">' +
+      '<span class="ann-icon">✍</span>' +
+      '<span class="ann-count">' + (count || '') + '</span>' +
+      '</span>');
+    if (count > 0) $ind.addClass('has-comments');
+    return $ind;
+  }
+
+  function formatTime(iso) {
+    if (!iso) return '';
+    var d = new Date(iso);
+    return d.toLocaleDateString() + ' ' + d.toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'});
+  }
+
+  function renderPanel(annId) {
+    var comments = AnnotationStore.getForElement(annId);
+
+    var $panel = $('<div class="annotation-panel open" data-panel-for="' + annId + '">');
+
+    // Header
+    var $header = $('<div class="ann-panel-header">' +
+      '<span class="ann-panel-title">Comments</span>' +
+      '<button class="ann-panel-close">&times;</button>' +
+      '</div>');
+    $panel.append($header);
+
+    // Print label (visible only in print)
+    $panel.append('<div class="ann-print-label">Comments:</div>');
+
+    // Comments list
+    var $list = $('<div class="ann-comments-list">');
+    if (comments.length === 0) {
+      $list.append('<div class="ann-empty">No comments yet.</div>');
+    } else {
+      var hasVisiblePrint = false;
+      comments.forEach(function(c) {
+        if (c.resolved && !showResolved) {
+          hasVisiblePrint = true; // still exists for print
+          var $entry = renderEntry(annId, c);
+          $entry.css('display', 'none').addClass('ann-hidden-resolved');
+          $list.append($entry);
+          return;
+        }
+        hasVisiblePrint = true;
+        $list.append(renderEntry(annId, c));
+      });
+      if (hasVisiblePrint) $panel.addClass('has-print-comments');
+    }
+    $panel.append($list);
+
+    // Input area
+    var $input = $('<div class="ann-input-area">' +
+      '<div class="ann-input-row">' +
+        '<label>Author</label>' +
+        '<input type="text" class="ann-author-input" placeholder="Your name" value="' + escHtml(getAuthor()) + '">' +
+      '</div>' +
+      '<textarea class="ann-text-input" placeholder="Write a comment..."></textarea>' +
+      '<div style="overflow:hidden;margin-top:6px;">' +
+        '<button class="ann-submit-btn">Add Comment</button>' +
+      '</div>' +
+      '</div>');
+    $panel.append($input);
+
+    return $panel;
+  }
+
+  function renderEntry(annId, c) {
+    var $entry = $('<div class="ann-entry" data-comment-id="' + c.id + '">');
+    if (c.resolved) $entry.addClass('resolved');
+
+    var timeStr = formatTime(c.modified || c.created);
+    $entry.append('<div class="ann-entry-header">' +
+      '<span class="ann-author">' + escHtml(c.author) + '</span>' +
+      '<span class="ann-time">' + timeStr + '</span>' +
+      '</div>');
+    $entry.append('<div class="ann-text">' + escHtml(c.text) + '</div>');
+
+    var $actions = $('<div class="ann-actions">');
+    var resLabel = c.resolved ? 'Unresolve' : 'Resolve';
+    var resCls = c.resolved ? ' is-resolved' : '';
+    $actions.append('<button class="ann-resolve-btn' + resCls + '" data-el="' + annId + '" data-cid="' + c.id + '">' + resLabel + '</button>');
+    $actions.append('<button class="ann-edit-btn" data-el="' + annId + '" data-cid="' + c.id + '">Edit</button>');
+    $actions.append('<button class="ann-delete-btn" data-el="' + annId + '" data-cid="' + c.id + '">Delete</button>');
+    $entry.append($actions);
+
+    return $entry;
+  }
+
+  function refreshPanel(annId) {
+    var $old = $('[data-panel-for="' + annId + '"]');
+    if ($old.length && $old.hasClass('open')) {
+      var $new = renderPanel(annId);
+      $old.replaceWith($new);
+    }
+    refreshIndicator(annId);
+    refreshToolbar();
+  }
+
+  function refreshIndicator(annId) {
+    var count = AnnotationStore.countForElement(annId);
+    var $ind = $('[data-for="' + annId + '"]');
+    $ind.find('.ann-count').text(count || '');
+    $ind.toggleClass('has-comments', count > 0);
+    // highlight the element
+    $('[data-annotation-id="' + annId + '"]').toggleClass('has-annotations', count > 0);
+  }
+
+  function refreshToolbar() {
+    var total = AnnotationStore.totalCount();
+    $('#annotation-toolbar .ann-toolbar-badge').text(total);
+  }
+
+  // ── Toolbar ──
+
+  function createToolbar() {
+    var total = AnnotationStore.totalCount();
+    var $tb = $('<div id="annotation-toolbar">' +
+      '<div class="ann-toolbar-main">' +
+        '<span class="ann-toolbar-badge">' + total + '</span> annotations ' +
+        '<button class="ann-export-btn" title="Export">Export</button>' +
+        '<button class="ann-import-btn" title="Import">Import</button>' +
+      '</div>' +
+      '<div class="ann-toolbar-options">' +
+        '<label><input type="checkbox" class="ann-show-resolved-chk"> Show resolved</label>' +
+      '</div>' +
+      '</div>');
+    $('body').append($tb);
+  }
+
+  // ── Event handlers ──
+
+  function bindEvents() {
+    // Toggle panel
+    $(document).on('click', '.annotation-indicator', function(e) {
+      e.stopPropagation();
+      var annId = $(this).data('for');
+      var $existing = $('[data-panel-for="' + annId + '"]');
+      if ($existing.length) {
+        if ($existing.hasClass('open')) {
+          $existing.removeClass('open').slideUp(150);
+        } else {
+          $existing.addClass('open').slideDown(150);
+        }
+        return;
+      }
+      // Create new panel
+      var $panel = renderPanel(annId);
+      var $el = $('[data-annotation-id="' + annId + '"]');
+      $el.after($panel);
+      $panel.hide().slideDown(200);
+    });
+
+    // Close panel
+    $(document).on('click', '.ann-panel-close', function() {
+      $(this).closest('.annotation-panel').removeClass('open').slideUp(150);
+    });
+
+    // Submit comment
+    $(document).on('click', '.ann-submit-btn', function() {
+      var $panel = $(this).closest('.annotation-panel');
+      var annId = $panel.data('panel-for');
+      var text = $panel.find('.ann-text-input').val().trim();
+      var author = $panel.find('.ann-author-input').val().trim() || 'Anonymous';
+      if (!text) return;
+      setAuthor(author);
+      AnnotationStore.addComment(annId, text, author);
+      refreshPanel(annId);
+    });
+
+    // Resolve toggle
+    $(document).on('click', '.ann-resolve-btn', function() {
+      var annId = $(this).data('el');
+      var cid = $(this).data('cid');
+      AnnotationStore.toggleResolved(annId, cid);
+      refreshPanel(annId);
+    });
+
+    // Edit
+    $(document).on('click', '.ann-edit-btn', function() {
+      var $entry = $(this).closest('.ann-entry');
+      var annId = $(this).data('el');
+      var cid = $(this).data('cid');
+      var currentText = $entry.find('.ann-text').text();
+      $entry.find('.ann-text').replaceWith(
+        '<textarea class="ann-edit-textarea">' + escHtml(currentText) + '</textarea>' +
+        '<div class="ann-edit-actions">' +
+          '<button class="ann-save-btn" data-el="' + annId + '" data-cid="' + cid + '">Save</button>' +
+          '<button class="ann-cancel-btn" data-el="' + annId + '">Cancel</button>' +
+        '</div>'
+      );
+      $entry.find('.ann-actions').hide();
+    });
+
+    // Save edit
+    $(document).on('click', '.ann-save-btn', function() {
+      var annId = $(this).data('el');
+      var cid = $(this).data('cid');
+      var newText = $(this).closest('.ann-entry').find('.ann-edit-textarea').val().trim();
+      if (newText) AnnotationStore.editComment(annId, cid, newText);
+      refreshPanel(annId);
+    });
+
+    // Cancel edit
+    $(document).on('click', '.ann-cancel-btn', function() {
+      var annId = $(this).data('el');
+      refreshPanel(annId);
+    });
+
+    // Delete
+    $(document).on('click', '.ann-delete-btn', function() {
+      if (!confirm('Delete this comment?')) return;
+      var annId = $(this).data('el');
+      var cid = $(this).data('cid');
+      AnnotationStore.deleteComment(annId, cid);
+      refreshPanel(annId);
+    });
+
+    // Show resolved toggle
+    $(document).on('change', '.ann-show-resolved-chk', function() {
+      showResolved = $(this).is(':checked');
+      // Re-render all open panels
+      $('.annotation-panel.open').each(function() {
+        var annId = $(this).data('panel-for');
+        refreshPanel(annId);
+      });
+      // Restore checkbox state
+      $('.ann-show-resolved-chk').prop('checked', showResolved);
+    });
+
+    // Export
+    $(document).on('click', '.ann-export-btn', function() {
+      var json = AnnotationStore.exportJSON();
+      var blob = new Blob([json], { type: 'application/json' });
+      var url = URL.createObjectURL(blob);
+      var a = document.createElement('a');
+      var date = new Date().toISOString().slice(0,10);
+      a.href = url;
+      a.download = 'blueprint-annotations-' + date + '.json';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    });
+
+    // Import
+    $(document).on('click', '.ann-import-btn', function() {
+      var input = document.createElement('input');
+      input.type = 'file';
+      input.accept = '.json';
+      input.onchange = function(e) {
+        var file = e.target.files[0];
+        if (!file) return;
+        var reader = new FileReader();
+        reader.onload = function(ev) {
+          var result = AnnotationStore.importJSON(ev.target.result);
+          if (result.error) {
+            alert('Import failed: ' + result.error);
+          } else {
+            alert('Imported ' + result.added + ' new comment(s).');
+            // Refresh all indicators
+            $('[data-annotation-id]').each(function() {
+              refreshIndicator($(this).data('annotation-id'));
+            });
+            refreshToolbar();
+          }
+        };
+        reader.readAsText(file);
+      };
+      input.click();
+    });
+  }
+
+  // ── Print preparation ──
+
+  function preparePrint() {
+    // Before printing, inject panels for elements with comments so they appear in print
+    window.addEventListener('beforeprint', function() {
+      $('[data-annotation-id]').each(function() {
+        var annId = $(this).data('annotation-id');
+        var count = AnnotationStore.countForElement(annId);
+        if (count === 0) return;
+        var $existing = $('[data-panel-for="' + annId + '"]');
+        if ($existing.length === 0) {
+          var $panel = renderPanel(annId);
+          $panel.removeClass('open').addClass('has-print-comments');
+          $(this).after($panel);
+        } else {
+          $existing.addClass('has-print-comments');
+        }
+      });
+    });
+  }
+
+  // ── Helpers ──
+
+  function escHtml(str) {
+    var div = document.createElement('div');
+    div.appendChild(document.createTextNode(str));
+    return div.innerHTML;
+  }
+
+  // ── Init ──
+
+  function init() {
+    assignAnnotationIds();
+
+    // Insert indicators
+    $('[data-annotation-id]').each(function() {
+      var $el = $(this);
+      var annId = $el.data('annotation-id');
+      var count = AnnotationStore.countForElement(annId);
+      var $ind = createIndicator(annId, count);
+
+      // For theorem-like wrappers: put in thm_header_extras
+      var $extras = $el.find('> [class$="_thmheading"] .thm_header_extras').first();
+      if ($extras.length) {
+        $extras.append($ind);
+      }
+      // For proof wrappers: put in proof_heading
+      else if ($el.hasClass('proof_wrapper')) {
+        $el.find('> .proof_heading').first().append($ind);
+      }
+      // For paragraphs: float to the right
+      else if ($el.is('p')) {
+        $el.css('position', 'relative');
+        $ind.addClass('ann-indicator-float');
+        $el.append($ind);
+      }
+
+      if (count > 0) $el.addClass('has-annotations');
+    });
+
+    createToolbar();
+    bindEvents();
+    preparePrint();
+  }
+
+  // Run on DOM ready
+  $(document).ready(function() {
+    init();
+  });
+
+})(jQuery);

--- a/blueprint/src/macros/common.tex
+++ b/blueprint/src/macros/common.tex
@@ -1,6 +1,6 @@
 \usepackage{algtop}
-\usepackage{amscd}
 \ifblueprintweb\else
+\usepackage{amscd}
 \usepackage[all, cmtip]{xy}
 \fi
 \ifblueprintweb\else

--- a/blueprint/src/plastex.cfg
+++ b/blueprint/src/plastex.cfg
@@ -13,7 +13,8 @@ split-level=1
 
 [html5]
 localtoc-level=0
-extra-css=extra_styles.css
+extra-css=extra_styles.css annotations.css
+extra-js=annotations.js
 mathjax-dollars=False
 
 [images]


### PR DESCRIPTION
## Summary
- Add localStorage-based comment/annotation system to blueprint web pages
- Users can annotate any definition, theorem, proof, or paragraph with ✍ icons
- Comments visible in browser print (`@media print`) and exportable as JSON with human-readable context (type, label, excerpt)
- Includes `inject_annotations.py` script to inject exported comments into LaTeX PDF as margin notes
- Fixes amscd plasTeX crash by restoring `\ifblueprintweb` guard in `common.tex`

## Files
| File | Description |
|------|-------------|
| `blueprint/src/annotations.js` | Core JS: localStorage store, UI, export/import with context |
| `blueprint/src/annotations.css` | Screen + `@media print` styles |
| `blueprint/inject_annotations.py` | LaTeX margin note injection script |
| `blueprint/src/plastex.cfg` | Register new JS/CSS in plasTeX config |
| `blueprint/build.sh` | Optional annotation injection step for PDF |
| `blueprint/src/macros/common.tex` | Fix amscd `\ifblueprintweb` guard |

## Test plan
- [ ] Run `leanblueprint web` and open any section page
- [ ] Verify ✍ icons appear on definitions/theorems/paragraphs
- [ ] Add a comment, refresh page, verify it persists (localStorage)
- [ ] Export JSON and verify context metadata (type, title, excerpt) is included
- [ ] Import JSON on another browser and verify merge
- [ ] Test browser Ctrl+P print preview shows comments inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)