### PR TITLE
feat: node-centric KIP dashboard (AUT-41)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ blueprint/src/*.bbl
 blueprint/src/*.pdf
 blueprint/src/content.md
 blueprint/src/content.tex.bak
+blueprint/status.yaml.bak
 blueprint/src/src/
 blueprint/src/web/
 blueprint/src/core.*

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ ui/server/node_modules/
 ui/server/dist/
 ui/client/node_modules/
 ui/client/dist/
+/.kip/

--- a/blueprint/status.yaml
+++ b/blueprint/status.yaml
@@ -7,18 +7,18 @@ nodes:
     proved: false
     kind: definition
     comments:
-      - topic: align
-        text: SSData字段顺序和NL不一致，建议p q互换
-        by: surenny
-        at: '2026-04-19'
-      - topic: general
-        text: 这个定义是整个谱序列的基础
-        by: wangguozhen
-        at: '2026-04-19'
-      - topic: general
-        text: 这是一个非常正确的形式化
-        by: web-reviewer
-        at: '2026-04-19'
+    - topic: align
+      text: SSData字段顺序和NL不一致，建议p q互换
+      by: surenny
+      at: '2026-04-19T12:00:00+08:00'
+    - topic: general
+      text: 这个定义是整个谱序列的基础
+      by: wangguozhen
+      at: '2026-04-19T12:00:00+08:00'
+    - topic: general
+      text: 这是一个非常正确的形式化
+      by: web-reviewer
+      at: '2026-04-19T12:00:00+08:00'
     nl_reviewer: test
     align_reviewer: web-reviewer
     nl_hash: 192c2f3b92f48706
@@ -30,7 +30,7 @@ nodes:
     proved: false
     kind: definition
     align_reviewer: web-reviewer
-    aligned_at: '2026-04-19'
+    aligned_at: '2026-04-19T12:00:00+08:00'
     nl_hash: 81e4dfd3fc37ef20
   prereq:def:einfty-data:
     lean_decl: KIP.SpectralSequence.SSData.eInfty
@@ -40,7 +40,7 @@ nodes:
     proved: false
     kind: definition
     align_reviewer: web-reviewer
-    aligned_at: '2026-04-19'
+    aligned_at: '2026-04-19T12:00:00+08:00'
     nl_hash: 83a891b656d5e2ff
   prereq:def:ss-morphism:
     lean_decl: KIP.SpectralSequence.SpectralSequenceMorphism
@@ -74,7 +74,7 @@ nodes:
     proved: false
     kind: definition
     nl_reviewer: test-ping
-    nl_reviewed_at: '2026-04-19'
+    nl_reviewed_at: '2026-04-19T12:00:00+08:00'
     nl_hash: ff79ac43a1565ea2
   prereq:def:filtration-degree:
     lean_decl: KIP.SpectralSequence.Convergence.filtrationDegree
@@ -121,10 +121,17 @@ nodes:
     lean_decl: KIP.SpectralSequence.FilteredMorphism
     nl_reviewed: true
     bound: true
-    aligned: false
+    aligned: true
     proved: false
     kind: definition
     nl_hash: 49d94e708caedb2d
+    comments:
+    - topic: align
+      text: Alignment confirmed
+      by: surenny
+      at: '2026-04-27T12:00:00+08:00'
+    align_reviewer: surenny
+    aligned_at: '2026-04-27T12:00:00+08:00'
   prereq:def:filtered-complex:
     lean_decl: KIP.SpectralSequence.FilteredComplex
     nl_reviewed: true
@@ -717,7 +724,7 @@ nodes:
     kind: remark
     nl_reviewed: true
     nl_reviewer: web-reviewer
-    nl_reviewed_at: '2026-04-19'
+    nl_reviewed_at: '2026-04-19T12:00:00+08:00'
     nl_hash: cda248a7a43d920b
   a0000000003:
     bound: false
@@ -1330,6 +1337,14 @@ nodes:
     bound: false
     nl_hash: 5214332db2d05bf8
     proved: false
+    comments:
+    - topic: nl-review
+      text: NL approved
+      by: surenny
+      at: '2026-04-27T12:00:00+08:00'
+    nl_reviewed: true
+    nl_reviewer: surenny
+    nl_reviewed_at: '2026-04-27T12:00:00+08:00'
   prereq:thm:unbounded-ess-convergence:
     kind: theorem
     bound: false
@@ -1342,10 +1357,26 @@ nodes:
     kind: proposition
     bound: false
     nl_hash: ce623afb9a54bec9
+    comments:
+    - topic: nl-review
+      text: NL approved
+      by: surenny
+      at: '2026-04-27T12:00:00+08:00'
+    nl_reviewed: true
+    nl_reviewer: surenny
+    nl_reviewed_at: '2026-04-27T12:00:00+08:00'
   prereq:prop:invlim-of-truncations-ss:
     kind: proposition
     bound: false
     nl_hash: 54cb7bf052d765c5
+    comments:
+    - topic: nl-review
+      text: NL approved
+      by: surenny
+      at: '2026-04-27T12:00:00+08:00'
+    nl_reviewed: true
+    nl_reviewer: surenny
+    nl_reviewed_at: '2026-04-27T12:00:00+08:00'
   prereq:def:unbounded-ess:
     kind: definition
     bound: false
@@ -1360,3 +1391,11 @@ nodes:
     kind: proposition
     bound: false
     nl_hash: 0fe575dc179e17ec
+    comments:
+    - topic: nl-review
+      text: NL approved
+      by: surenny
+      at: '2026-04-27T12:00:00+08:00'
+    nl_reviewed: true
+    nl_reviewer: surenny
+    nl_reviewed_at: '2026-04-27T12:00:00+08:00'

--- a/tools/kip-state/backfill_yaml_times.py
+++ b/tools/kip-state/backfill_yaml_times.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""One-shot upgrade for legacy date-only timestamps in blueprint/status.yaml.
+
+Older entries store `nl_reviewed_at`, `aligned_at`, and `comments[].at` as
+plain dates (e.g. '2026-04-19'). The dashboard wants minute-level precision so
+reviewers can compare when each comment landed; the indexer's relative-time
+display also needs an unambiguous instant.
+
+This script rewrites every date-only string into noon Beijing of that date —
+'2026-04-19T12:00:00+08:00' — which is:
+
+  * minute-precise (so the UI no longer falls back to a bare date),
+  * a defensible midpoint that doesn't drift more than 12h in either zone,
+  * lexicographically equal to the original date for index.py's `max(...)`
+    over `last_activity` (still sorts on day boundaries),
+  * idempotent: re-running won't touch already-precise ISO timestamps.
+
+Run from project root:
+    python3 tools/kip-state/backfill_yaml_times.py [--dry-run]
+
+Always keep the previous file as `.bak` next to it for trivial rollback.
+"""
+from __future__ import annotations
+import argparse
+import re
+import shutil
+import sys
+from pathlib import Path
+
+import yaml
+
+DATE_ONLY = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+NOON_BEIJING_SUFFIX = "T12:00:00+08:00"
+
+
+def upgrade(value: object) -> tuple[object, bool]:
+    if isinstance(value, str) and DATE_ONLY.match(value):
+        return value + NOON_BEIJING_SUFFIX, True
+    return value, False
+
+
+def walk(data: dict) -> int:
+    """Walk known timestamp fields under data['nodes'][*]. Returns change count."""
+    changed = 0
+    nodes = data.get("nodes") or {}
+    for entry in nodes.values():
+        if not isinstance(entry, dict):
+            continue
+        for key in ("nl_reviewed_at", "aligned_at"):
+            new, was_changed = upgrade(entry.get(key))
+            if was_changed:
+                entry[key] = new
+                changed += 1
+        for c in entry.get("comments") or []:
+            if not isinstance(c, dict):
+                continue
+            new, was_changed = upgrade(c.get("at"))
+            if was_changed:
+                c["at"] = new
+                changed += 1
+    return changed
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--project", type=Path, default=Path.cwd())
+    ap.add_argument("--dry-run", action="store_true",
+                    help="report changes without writing")
+    args = ap.parse_args(argv)
+
+    yaml_path = args.project / "blueprint" / "status.yaml"
+    if not yaml_path.exists():
+        print(f"error: not found: {yaml_path}", file=sys.stderr)
+        return 1
+
+    text = yaml_path.read_text()
+    data = yaml.safe_load(text) or {}
+    n = walk(data)
+    print(f"upgraded {n} date-only timestamp(s) in {yaml_path}")
+    if args.dry_run or n == 0:
+        return 0
+
+    bak = yaml_path.with_suffix(yaml_path.suffix + ".bak")
+    shutil.copy2(yaml_path, bak)
+    yaml_path.write_text(yaml.safe_dump(
+        data, allow_unicode=True, sort_keys=False, default_flow_style=False))
+    print(f"wrote new {yaml_path} (backup at {bak})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/kip-state/index.py
+++ b/tools/kip-state/index.py
@@ -375,8 +375,8 @@ def main(argv: list[str] | None = None) -> int:
     orphan_edges = 0
     for src, dst in edges:
         if src in all_ids and dst in all_ids:
-            cur.execute("""INSERT OR IGNORE INTO edges(from_node, to_node, source, confirmed)
-                           VALUES(?,?,?,?)""", (src, dst, "latex", 0))
+            cur.execute("""INSERT OR IGNORE INTO edges(from_node, to_node, source)
+                           VALUES(?,?,?)""", (src, dst, "latex"))
         else:
             orphan_edges += 1
     if orphan_edges:

--- a/tools/kip-state/index.py
+++ b/tools/kip-state/index.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+r"""Build .kip/state.db from project sources.
+
+Inputs:
+  blueprint/status.yaml          - node lifecycle flags, comments
+  blueprint/src/chapters/*.tex   - node IDs, kinds, edges (\uses), Lean bindings (\lean), \leanok
+  KIP/**/*.lean                  - declarations + sorry counts (per fully-qualified name)
+  agents/*/logs/run-*/           - agent runs (meta.json + .jsonl with session_end)
+
+Output: .kip/state.db (SQLite, gitignored, safe to drop)
+
+Usage:
+  python tools/kip-state/index.py [--project PATH] [--db PATH]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sqlite3
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+
+KIND_PATTERN = r"theorem|definition|lemma|proposition|corollary|axiom|notation|remark|question|example"
+RE_BEGIN = re.compile(r"\\begin\{(" + KIND_PATTERN + r")\*?\}")
+RE_END = re.compile(r"\\end\{(" + KIND_PATTERN + r")\*?\}")
+RE_LABEL = re.compile(r"\\label\{([^}]+)\}")
+RE_USES = re.compile(r"\\uses\{([^}]+)\}")
+RE_LEAN = re.compile(r"\\lean\{([^}]+)\}")
+RE_LEANOK = re.compile(r"\\leanok\b")
+
+RE_LEAN_DECL = re.compile(r"^\s*(?:@\[[^\]]*\]\s*)*"
+                          r"(?:noncomputable\s+|private\s+|protected\s+|partial\s+)*"
+                          r"(theorem|lemma|def|abbrev|axiom|structure|class|instance)\s+"
+                          r"([A-Za-z_][A-Za-z0-9_'\.]*)")
+RE_LEAN_NS = re.compile(r"^\s*namespace\s+([A-Za-z_][A-Za-z0-9_'\.]*)")
+RE_LEAN_NS_END = re.compile(r"^\s*end\s+([A-Za-z_][A-Za-z0-9_'\.]*)?\s*$")
+RE_SORRY = re.compile(r"\bsorry\b")
+
+
+@dataclass
+class ParsedNode:
+    id: str
+    kind: str
+    chapter: str
+    source_file: str
+    source_line: int
+    lean_decl: str | None = None
+    leanok: bool = False
+    edges_to: list[str] = field(default_factory=list)
+
+
+def parse_chapters(chapters_dir: Path) -> tuple[dict[str, ParsedNode], list[tuple[str, str]]]:
+    """Walk all chapter .tex files, return (nodes_by_id, edges)."""
+    nodes: dict[str, ParsedNode] = {}
+    edges: list[tuple[str, str]] = []
+
+    for tex in sorted(chapters_dir.glob("*.tex")):
+        chapter = tex.stem
+        try:
+            lines = tex.read_text(encoding="utf-8").splitlines()
+        except UnicodeDecodeError:
+            lines = tex.read_text(encoding="latin-1").splitlines()
+
+        block_kind: str | None = None
+        block_start: int = 0
+        block_text: list[str] = []
+
+        def finalize(end_line: int) -> None:
+            nonlocal block_kind, block_text, block_start
+            if block_kind is None:
+                return
+            text = "\n".join(block_text)
+            label_m = RE_LABEL.search(text)
+            if not label_m:
+                block_kind = None
+                block_text = []
+                return
+            nid = label_m.group(1)
+            node = ParsedNode(
+                id=nid,
+                kind=block_kind,
+                chapter=chapter,
+                source_file=str(tex),
+                source_line=block_start,
+            )
+            for m in RE_USES.finditer(text):
+                for tgt in m.group(1).split(","):
+                    tgt = tgt.strip()
+                    if tgt:
+                        edges.append((nid, tgt))
+                        node.edges_to.append(tgt)
+            lean_m = RE_LEAN.search(text)
+            if lean_m:
+                node.lean_decl = lean_m.group(1).strip()
+            if RE_LEANOK.search(text):
+                node.leanok = True
+            nodes[nid] = node  # last definition wins on duplicate
+            block_kind = None
+            block_text = []
+
+        for idx, line in enumerate(lines, start=1):
+            mb = RE_BEGIN.search(line)
+            me = RE_END.search(line)
+            if mb and block_kind is None:
+                block_kind = mb.group(1)
+                block_start = idx
+                block_text = [line]
+                continue
+            if block_kind is not None:
+                block_text.append(line)
+                if me and me.group(1) == block_kind:
+                    finalize(idx)
+
+    return nodes, edges
+
+
+def parse_lean_sources(lean_root: Path) -> dict[str, dict]:
+    """Return fully-qualified name → {file, line_start, line_end, sorry_count}."""
+    out: dict[str, dict] = {}
+    for path in sorted(lean_root.rglob("*.lean")):
+        rel = str(path.relative_to(lean_root.parent))
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except UnicodeDecodeError:
+            continue
+        ns_stack: list[str] = []
+        decls: list[tuple[str, int]] = []  # (qualified_name, line)
+        for i, raw in enumerate(lines, start=1):
+            line = raw.split("--", 1)[0]  # crude single-line comment strip
+            mns = RE_LEAN_NS.match(line)
+            if mns:
+                ns_stack.append(mns.group(1))
+                continue
+            mne = RE_LEAN_NS_END.match(line)
+            if mne and ns_stack:
+                # Only pop if `end <name>` matches the top namespace.
+                # `end SectionName` closes a section, not a namespace, and
+                # bare `end` (no name) is ambiguous — ignore both.
+                end_name = mne.group(1)
+                if end_name and end_name == ns_stack[-1]:
+                    ns_stack.pop()
+                continue
+            md = RE_LEAN_DECL.match(line)
+            if md:
+                name = md.group(2)
+                qualified = ".".join(ns_stack + [name]) if ns_stack else name
+                decls.append((qualified, i))
+
+        decls.append(("__END__", len(lines) + 1))
+        for (name, start), (_, next_start) in zip(decls, decls[1:]):
+            body = "\n".join(lines[start - 1 : next_start - 1])
+            sorry_count = len(RE_SORRY.findall(body))
+            out[name] = {
+                "file": rel,
+                "line_start": start,
+                "line_end": next_start - 1,
+                "sorry_count": sorry_count,
+            }
+    return out
+
+
+@dataclass
+class AgentRun:
+    id: str
+    agent: str
+    started_at: str | None
+    completed_at: str | None
+    status: str | None
+    model: str | None
+    hint_file: str | None
+    cost_usd: float | None = None
+    duration_ms: int | None = None
+    num_turns: int | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    summary: str | None = None
+    log_path: str | None = None
+    touched_text: str = ""  # bag for node-id matching
+
+
+def parse_agent_runs(agents_dir: Path) -> list[AgentRun]:
+    runs: list[AgentRun] = []
+    if not agents_dir.exists():
+        return runs
+    for agent_dir in sorted(agents_dir.iterdir()):
+        if not agent_dir.is_dir():
+            continue
+        logs_dir = agent_dir / "logs"
+        if not logs_dir.is_dir():
+            continue
+        for run_dir in sorted(logs_dir.iterdir()):
+            if not run_dir.is_dir() or not run_dir.name.startswith("run-"):
+                continue
+            meta_path = run_dir / "meta.json"
+            if not meta_path.exists():
+                continue
+            try:
+                meta = json.loads(meta_path.read_text())
+            except json.JSONDecodeError:
+                continue
+            jsonl_files = sorted(run_dir.glob("*.jsonl"))
+            log_path = str(jsonl_files[0]) if jsonl_files else None
+            session_end = None
+            text_buf: list[str] = []
+            for jf in jsonl_files:
+                with jf.open() as f:
+                    for raw in f:
+                        try:
+                            ev = json.loads(raw)
+                        except json.JSONDecodeError:
+                            continue
+                        if ev.get("event") == "session_end":
+                            session_end = ev
+                        for k in ("content", "summary"):
+                            v = ev.get(k)
+                            if isinstance(v, str):
+                                text_buf.append(v)
+                            elif isinstance(v, (dict, list)):
+                                text_buf.append(json.dumps(v))
+            run = AgentRun(
+                id=run_dir.name,
+                agent=meta.get("agent") or agent_dir.name,
+                started_at=meta.get("startedAt"),
+                completed_at=meta.get("completedAt"),
+                status=meta.get("status"),
+                model=meta.get("model"),
+                hint_file=meta.get("hint_file"),
+                log_path=log_path,
+            )
+            if session_end:
+                run.cost_usd = session_end.get("total_cost_usd")
+                run.duration_ms = session_end.get("duration_ms")
+                run.num_turns = session_end.get("num_turns")
+                run.input_tokens = session_end.get("input_tokens")
+                run.output_tokens = session_end.get("output_tokens")
+                run.summary = session_end.get("summary")
+                if not run.model:
+                    mu = session_end.get("model_usage") or {}
+                    if mu:
+                        run.model = next(iter(mu))
+            run.touched_text = "\n".join(text_buf)
+            runs.append(run)
+    return runs
+
+
+def derive_phase(row: dict) -> str:
+    """Map flag combination to a single phase enum.
+
+    Uses the natural order; later flags imply earlier ones for display purposes,
+    but we keep the *deepest* flag set as the phase label.
+    nl_reviewed implicitly includes "dependency edges confirmed"."""
+    if row.get("proved"):
+        return "proved"
+    if row.get("aligned"):
+        return "aligned"
+    if row.get("bound"):
+        return "bound"
+    if row.get("nl_reviewed"):
+        return "nl_reviewed"
+    return "drafted"
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--project", type=Path, default=Path.cwd(),
+                    help="KIP project root (default: cwd)")
+    ap.add_argument("--db", type=Path, default=None,
+                    help="Output SQLite path (default: <project>/.kip/state.db)")
+    ap.add_argument("--quiet", action="store_true")
+    args = ap.parse_args(argv)
+
+    project: Path = args.project.resolve()
+    db_path: Path = args.db or (project / ".kip" / "state.db")
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    log = (lambda *a, **k: None) if args.quiet else (lambda *a, **k: print(*a, **k, file=sys.stderr))
+
+    schema_path = Path(__file__).parent / "schema.sql"
+    schema_sql = schema_path.read_text()
+
+    status_path = project / "blueprint" / "status.yaml"
+    chapters_dir = project / "blueprint" / "src" / "chapters"
+    lean_root = project / "KIP"
+    agents_dir = project / "agents"
+
+    log(f"[kip-state] project={project}")
+    log(f"[kip-state] db={db_path}")
+
+    if db_path.exists():
+        db_path.unlink()
+    conn = sqlite3.connect(db_path)
+    conn.executescript(schema_sql)
+
+    # ---- chapters: node skeletons + edges --------------------------------
+    chapter_nodes, edges = parse_chapters(chapters_dir)
+    log(f"[kip-state] chapters: {len(chapter_nodes)} nodes, {len(edges)} edges")
+
+    # ---- status.yaml: lifecycle flags + comments -------------------------
+    status_data = yaml.safe_load(status_path.read_text()) if status_path.exists() else {}
+    status_nodes = status_data.get("nodes", {}) if isinstance(status_data, dict) else {}
+    log(f"[kip-state] status.yaml: {len(status_nodes)} entries")
+
+    # union of node IDs from both sources
+    all_ids = set(chapter_nodes.keys()) | set(status_nodes.keys())
+
+    # ---- lean source: declarations + sorries -----------------------------
+    lean_decls = parse_lean_sources(lean_root) if lean_root.exists() else {}
+    log(f"[kip-state] lean: {len(lean_decls)} declarations")
+
+    # ---- agent runs ------------------------------------------------------
+    runs = parse_agent_runs(agents_dir)
+    log(f"[kip-state] agent runs: {len(runs)}")
+
+    # =====================================================================
+    # write nodes
+    # =====================================================================
+    cur = conn.cursor()
+    for nid in sorted(all_ids):
+        cn = chapter_nodes.get(nid)
+        sn = status_nodes.get(nid) or {}
+        kind = (cn.kind if cn else None) or sn.get("kind")
+        chapter = cn.chapter if cn else None
+        source_file = cn.source_file if cn else None
+        source_line = cn.source_line if cn else None
+        lean_decl = (cn.lean_decl if cn else None) or sn.get("lean_decl")
+        leanok = 1 if (cn and cn.leanok) else 0
+
+        nl_reviewed = 1 if sn.get("nl_reviewed") else 0
+        bound = 1 if sn.get("bound") else 0
+        aligned = 1 if sn.get("aligned") else 0
+        proved = 1 if sn.get("proved") else 0
+
+        comment_times = [c.get("at") for c in (sn.get("comments") or []) if c.get("at")]
+        last_activity_candidates = [t for t in [sn.get("aligned_at"), *comment_times] if t]
+        last_activity = max(last_activity_candidates) if last_activity_candidates else None
+
+        row = dict(
+            id=nid, kind=kind, chapter=chapter,
+            source_file=source_file, source_line=source_line,
+            lean_decl=lean_decl, leanok=leanok,
+            nl_hash=sn.get("nl_hash"),
+            nl_reviewed=nl_reviewed,
+            bound=bound, aligned=aligned, proved=proved,
+            nl_reviewer=sn.get("nl_reviewer"),
+            align_reviewer=sn.get("align_reviewer"),
+            aligned_at=sn.get("aligned_at"),
+            last_activity=last_activity,
+            phase=derive_phase(dict(
+                nl_reviewed=nl_reviewed,
+                bound=bound, aligned=aligned, proved=proved,
+            )),
+        )
+        cur.execute("""INSERT INTO nodes
+            (id, kind, chapter, source_file, source_line, lean_decl, leanok,
+             nl_hash, nl_reviewed, bound, aligned, proved,
+             nl_reviewer, align_reviewer, aligned_at, last_activity, phase)
+            VALUES (:id,:kind,:chapter,:source_file,:source_line,:lean_decl,:leanok,
+                    :nl_hash,:nl_reviewed,:bound,:aligned,:proved,
+                    :nl_reviewer,:align_reviewer,:aligned_at,:last_activity,:phase)""",
+                    row)
+
+        for i, c in enumerate(sn.get("comments") or []):
+            cur.execute("""INSERT INTO node_comments(node_id, idx, topic, text, by, at)
+                           VALUES(?,?,?,?,?,?)""",
+                        (nid, i, c.get("topic"), c.get("text"), c.get("by"), c.get("at")))
+
+    # =====================================================================
+    # write edges (only those whose endpoints are known; orphans logged)
+    # =====================================================================
+    orphan_edges = 0
+    for src, dst in edges:
+        if src in all_ids and dst in all_ids:
+            cur.execute("""INSERT OR IGNORE INTO edges(from_node, to_node, source, confirmed)
+                           VALUES(?,?,?,?)""", (src, dst, "latex", 0))
+        else:
+            orphan_edges += 1
+    if orphan_edges:
+        log(f"[kip-state] WARN: {orphan_edges} edges reference unknown labels (skipped)")
+
+    # =====================================================================
+    # write lean_decls
+    # =====================================================================
+    for name, d in lean_decls.items():
+        cur.execute("""INSERT INTO lean_decls(name, file, line_start, line_end, sorry_count)
+                       VALUES(?,?,?,?,?)""",
+                    (name, d["file"], d["line_start"], d["line_end"], d["sorry_count"]))
+
+    # =====================================================================
+    # write agent_runs + node associations
+    # =====================================================================
+    for r in runs:
+        cur.execute("""INSERT INTO agent_runs
+            (id, agent, started_at, completed_at, status, model, hint_file,
+             cost_usd, duration_ms, num_turns, input_tokens, output_tokens,
+             summary, log_path)
+            VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+            (r.id, r.agent, r.started_at, r.completed_at, r.status, r.model,
+             r.hint_file, r.cost_usd, r.duration_ms, r.num_turns,
+             r.input_tokens, r.output_tokens, r.summary, r.log_path))
+
+        # match by literal ID occurrence in summary+log content. Naive but effective
+        # because labels like `prereq:def:ss-data` are unique and rarely false-positive.
+        if r.touched_text:
+            for nid in all_ids:
+                if nid in r.touched_text:
+                    cur.execute("""INSERT OR IGNORE INTO agent_run_nodes(run_id, node_id)
+                                   VALUES(?,?)""", (r.id, nid))
+
+    # =====================================================================
+    # back-fill last_activity from agent runs
+    # =====================================================================
+    cur.execute("""
+        UPDATE nodes SET last_activity = COALESCE(
+            (SELECT MAX(ar.completed_at)
+               FROM agent_run_nodes arn
+               JOIN agent_runs ar ON ar.id = arn.run_id
+              WHERE arn.node_id = nodes.id
+                AND ar.completed_at IS NOT NULL
+                AND (nodes.last_activity IS NULL
+                     OR ar.completed_at > nodes.last_activity)),
+            nodes.last_activity)
+    """)
+
+    cur.execute("INSERT INTO meta(key,value) VALUES(?,?)",
+                ("indexed_at", datetime.now(timezone.utc).isoformat()))
+    cur.execute("INSERT INTO meta(key,value) VALUES(?,?)",
+                ("schema_version", "1"))
+
+    conn.commit()
+    conn.close()
+
+    # summary line for CI / humans
+    print(f"[kip-state] OK · {len(all_ids)} nodes · {len(edges)} edges "
+          f"· {len(lean_decls)} lean decls · {len(runs)} agent runs · {db_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/kip-state/index.py
+++ b/tools/kip-state/index.py
@@ -32,6 +32,10 @@ RE_LABEL = re.compile(r"\\label\{([^}]+)\}")
 RE_USES = re.compile(r"\\uses\{([^}]+)\}")
 RE_LEAN = re.compile(r"\\lean\{([^}]+)\}")
 RE_LEANOK = re.compile(r"\\leanok\b")
+RE_SUBSEC = re.compile(r"\\subsection\*?\{([^}]+)\}")
+RE_SUBSUBSEC = re.compile(r"\\subsubsection\*?\{([^}]+)\}")
+# Order matters: \subsubsection contains \subsection, so check the longer
+# prefix first when classifying a heading line.
 
 RE_LEAN_DECL = re.compile(r"^\s*(?:@\[[^\]]*\]\s*)*"
                           r"(?:noncomputable\s+|private\s+|protected\s+|partial\s+)*"
@@ -49,6 +53,11 @@ class ParsedNode:
     chapter: str
     source_file: str
     source_line: int
+    # Deepest LaTeX heading the node sits under (subsubsection if available,
+    # else subsection). The chapter file itself is one \section, so this is
+    # always finer-grained than the chapter and gives the dashboard something
+    # to cluster sub-bodies by.
+    subsection: str | None = None
     lean_decl: str | None = None
     leanok: bool = False
     edges_to: list[str] = field(default_factory=list)
@@ -69,6 +78,11 @@ def parse_chapters(chapters_dir: Path) -> tuple[dict[str, ParsedNode], list[tupl
         block_kind: str | None = None
         block_start: int = 0
         block_text: list[str] = []
+        # Track the most recent LaTeX heading below \section so each parsed
+        # node can be attributed to its tightest container. \subsubsection
+        # wins over \subsection; either resets when a deeper heading opens.
+        cur_subsection: str | None = None
+        cur_subsubsec: str | None = None
 
         def finalize(end_line: int) -> None:
             nonlocal block_kind, block_text, block_start
@@ -87,6 +101,7 @@ def parse_chapters(chapters_dir: Path) -> tuple[dict[str, ParsedNode], list[tupl
                 chapter=chapter,
                 source_file=str(tex),
                 source_line=block_start,
+                subsection=cur_subsubsec or cur_subsection,
             )
             for m in RE_USES.finditer(text):
                 for tgt in m.group(1).split(","):
@@ -104,6 +119,21 @@ def parse_chapters(chapters_dir: Path) -> tuple[dict[str, ParsedNode], list[tupl
             block_text = []
 
         for idx, line in enumerate(lines, start=1):
+            # Heading detection runs whenever we're not inside an environment;
+            # being inside one prevents a stray \subsection in a docstring or
+            # comment-out from changing the section context for following
+            # nodes. Headings can technically be nested deeper than env open,
+            # but that doesn't happen in this project.
+            if block_kind is None:
+                # Check subsubsection first — RE_SUBSEC would match it too.
+                sm3 = RE_SUBSUBSEC.search(line)
+                if sm3:
+                    cur_subsubsec = sm3.group(1).strip()
+                else:
+                    sm2 = RE_SUBSEC.search(line)
+                    if sm2:
+                        cur_subsection = sm2.group(1).strip()
+                        cur_subsubsec = None  # leaving the previous subsubsec
             mb = RE_BEGIN.search(line)
             me = RE_END.search(line)
             if mb and block_kind is None:
@@ -325,6 +355,7 @@ def main(argv: list[str] | None = None) -> int:
         sn = status_nodes.get(nid) or {}
         kind = (cn.kind if cn else None) or sn.get("kind")
         chapter = cn.chapter if cn else None
+        subsection = cn.subsection if cn else None
         source_file = cn.source_file if cn else None
         source_line = cn.source_line if cn else None
         lean_decl = (cn.lean_decl if cn else None) or sn.get("lean_decl")
@@ -340,7 +371,7 @@ def main(argv: list[str] | None = None) -> int:
         last_activity = max(last_activity_candidates) if last_activity_candidates else None
 
         row = dict(
-            id=nid, kind=kind, chapter=chapter,
+            id=nid, kind=kind, chapter=chapter, subsection=subsection,
             source_file=source_file, source_line=source_line,
             lean_decl=lean_decl, leanok=leanok,
             nl_hash=sn.get("nl_hash"),
@@ -356,10 +387,10 @@ def main(argv: list[str] | None = None) -> int:
             )),
         )
         cur.execute("""INSERT INTO nodes
-            (id, kind, chapter, source_file, source_line, lean_decl, leanok,
+            (id, kind, chapter, subsection, source_file, source_line, lean_decl, leanok,
              nl_hash, nl_reviewed, bound, aligned, proved,
              nl_reviewer, align_reviewer, aligned_at, last_activity, phase)
-            VALUES (:id,:kind,:chapter,:source_file,:source_line,:lean_decl,:leanok,
+            VALUES (:id,:kind,:chapter,:subsection,:source_file,:source_line,:lean_decl,:leanok,
                     :nl_hash,:nl_reviewed,:bound,:aligned,:proved,
                     :nl_reviewer,:align_reviewer,:aligned_at,:last_activity,:phase)""",
                     row)

--- a/tools/kip-state/schema.sql
+++ b/tools/kip-state/schema.sql
@@ -30,7 +30,8 @@ CREATE TABLE edges (
   from_node TEXT NOT NULL,               -- the node that contains \uses{...}
   to_node   TEXT NOT NULL,               -- the dependency
   source    TEXT NOT NULL DEFAULT 'latex',
-  confirmed INTEGER NOT NULL DEFAULT 0,
+  -- No per-edge confirmation: NL review confirms the whole containing node,
+  -- which transitively vouches for its \uses{} list. See PR thread on AUT-41.
   PRIMARY KEY (from_node, to_node)
 );
 CREATE INDEX idx_edges_to ON edges(to_node);

--- a/tools/kip-state/schema.sql
+++ b/tools/kip-state/schema.sql
@@ -1,0 +1,79 @@
+-- KIP project state index. Built from status.yaml + blueprint LaTeX + Lean source + agent logs.
+-- This is a derived cache; truth lives in the files. Safe to drop and rebuild anytime.
+
+CREATE TABLE meta (
+  key   TEXT PRIMARY KEY,
+  value TEXT
+);
+
+CREATE TABLE nodes (
+  id              TEXT PRIMARY KEY,
+  kind            TEXT,                  -- definition / theorem / lemma / proposition / corollary / axiom / notation / remark / question / example
+  chapter         TEXT,                  -- chapter file stem
+  source_file     TEXT,
+  source_line     INTEGER,
+  lean_decl       TEXT,                  -- from \lean{...}
+  leanok          INTEGER NOT NULL DEFAULT 0,  -- \leanok marker present
+  nl_hash         TEXT,
+  nl_reviewed     INTEGER NOT NULL DEFAULT 0,
+  bound           INTEGER NOT NULL DEFAULT 0,
+  aligned         INTEGER NOT NULL DEFAULT 0,
+  proved          INTEGER NOT NULL DEFAULT 0,
+  nl_reviewer     TEXT,
+  align_reviewer  TEXT,
+  aligned_at      TEXT,
+  last_activity   TEXT,                  -- ISO-8601, computed from comments/runs/aligned_at
+  phase           TEXT NOT NULL DEFAULT 'drafted'  -- derived: drafted|nl_reviewed|bound|aligned|proved
+);
+
+CREATE TABLE edges (
+  from_node TEXT NOT NULL,               -- the node that contains \uses{...}
+  to_node   TEXT NOT NULL,               -- the dependency
+  source    TEXT NOT NULL DEFAULT 'latex',
+  confirmed INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (from_node, to_node)
+);
+CREATE INDEX idx_edges_to ON edges(to_node);
+
+CREATE TABLE node_comments (
+  node_id TEXT NOT NULL,
+  idx     INTEGER NOT NULL,
+  topic   TEXT,
+  text    TEXT,
+  by      TEXT,
+  at      TEXT,
+  PRIMARY KEY (node_id, idx)
+);
+
+CREATE TABLE lean_decls (
+  name        TEXT PRIMARY KEY,          -- fully qualified
+  file        TEXT,
+  line_start  INTEGER,
+  line_end    INTEGER,
+  sorry_count INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE agent_runs (
+  id            TEXT PRIMARY KEY,        -- run-<ts> directory name
+  agent         TEXT,
+  started_at    TEXT,
+  completed_at  TEXT,
+  status        TEXT,
+  model         TEXT,
+  hint_file     TEXT,
+  cost_usd      REAL,
+  duration_ms   INTEGER,
+  num_turns     INTEGER,
+  input_tokens  INTEGER,
+  output_tokens INTEGER,
+  summary       TEXT,
+  log_path      TEXT                     -- path to the .jsonl log
+);
+CREATE INDEX idx_runs_started ON agent_runs(started_at);
+
+CREATE TABLE agent_run_nodes (
+  run_id  TEXT NOT NULL,
+  node_id TEXT NOT NULL,
+  PRIMARY KEY (run_id, node_id)
+);
+CREATE INDEX idx_run_nodes_node ON agent_run_nodes(node_id);

--- a/tools/kip-state/schema.sql
+++ b/tools/kip-state/schema.sql
@@ -10,6 +10,7 @@ CREATE TABLE nodes (
   id              TEXT PRIMARY KEY,
   kind            TEXT,                  -- definition / theorem / lemma / proposition / corollary / axiom / notation / remark / question / example
   chapter         TEXT,                  -- chapter file stem
+  subsection      TEXT,                  -- deepest LaTeX heading below \section (subsubsection if available, else subsection)
   source_file     TEXT,
   source_line     INTEGER,
   lean_decl       TEXT,                  -- from \lean{...}

--- a/ui/client/package-lock.json
+++ b/ui/client/package-lock.json
@@ -9,7 +9,11 @@
       "version": "1.0.0",
       "dependencies": {
         "@tanstack/react-query": "^5.40.0",
+        "@types/cytoscape": "^3.21.9",
+        "cytoscape": "^3.33.2",
+        "cytoscape-dagre": "^2.5.0",
         "react": "^18.3.1",
+        "react-cytoscapejs": "^2.0.0",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.23.1"
       },
@@ -1181,6 +1185,12 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/cytoscape": {
+      "version": "3.21.9",
+      "resolved": "https://registry.npmjs.org/@types/cytoscape/-/cytoscape-3.21.9.tgz",
+      "integrity": "sha512-JyrG4tllI6jvuISPjHK9j2Xv/LTbnLekLke5otGStjFluIyA9JjgnvgZrSBsp8cEDpiTjwgZUZwpPv8TSBcoLw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1319,6 +1329,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cytoscape": {
+      "version": "3.33.2",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.2.tgz",
+      "integrity": "sha512-sj4HXd3DokGhzZAdjDejGvTPLqlt84vNFN8m7bGsOzDY5DyVcxIb2ejIXat2Iy7HxWhdT/N1oKyheJ5YdpsGuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-dagre": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-dagre/-/cytoscape-dagre-2.5.0.tgz",
+      "integrity": "sha512-VG2Knemmshop4kh5fpLO27rYcyUaaDkRw+6PiX4bstpB+QFt0p2oauMrsjVbUamGWQ6YNavh7x2em2uZlzV44g==",
+      "license": "MIT",
+      "dependencies": {
+        "dagre": "^0.8.5"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.22"
+      }
+    },
+    "node_modules/dagre": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/dagre/-/dagre-0.8.5.tgz",
+      "integrity": "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "graphlib": "^2.1.8",
+        "lodash": "^4.17.15"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1418,6 +1459,15 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/graphlib": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
+      "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.15"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1449,6 +1499,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -1505,6 +1561,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1541,6 +1606,17 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -1551,6 +1627,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-cytoscapejs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-cytoscapejs/-/react-cytoscapejs-2.0.0.tgz",
+      "integrity": "sha512-t3SSl1DQy7+JQjN+8QHi1anEJlM3i3aAeydHTsJwmjo/isyKK7Rs7oCvU6kZsB9NwZidzZQR21Vm2PcBLG/Tjg==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.19",
+        "react": ">=15.0.0"
       }
     },
     "node_modules/react-dom": {
@@ -1565,6 +1654,12 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",

--- a/ui/client/package-lock.json
+++ b/ui/client/package-lock.json
@@ -9,12 +9,10 @@
       "version": "1.0.0",
       "dependencies": {
         "@tanstack/react-query": "^5.40.0",
-        "@types/cytoscape": "^3.21.9",
-        "cytoscape": "^3.33.2",
-        "cytoscape-dagre": "^2.5.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^6.23.1"
+        "react-router-dom": "^6.23.1",
+        "svg-pan-zoom": "^3.6.2"
       },
       "devDependencies": {
         "@types/react": "^18.3.3",
@@ -1184,12 +1182,6 @@
         "@babel/types": "^7.28.2"
       }
     },
-    "node_modules/@types/cytoscape": {
-      "version": "3.21.9",
-      "resolved": "https://registry.npmjs.org/@types/cytoscape/-/cytoscape-3.21.9.tgz",
-      "integrity": "sha512-JyrG4tllI6jvuISPjHK9j2Xv/LTbnLekLke5otGStjFluIyA9JjgnvgZrSBsp8cEDpiTjwgZUZwpPv8TSBcoLw==",
-      "license": "MIT"
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1328,37 +1320,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cytoscape": {
-      "version": "3.33.2",
-      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.2.tgz",
-      "integrity": "sha512-sj4HXd3DokGhzZAdjDejGvTPLqlt84vNFN8m7bGsOzDY5DyVcxIb2ejIXat2Iy7HxWhdT/N1oKyheJ5YdpsGuw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/cytoscape-dagre": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/cytoscape-dagre/-/cytoscape-dagre-2.5.0.tgz",
-      "integrity": "sha512-VG2Knemmshop4kh5fpLO27rYcyUaaDkRw+6PiX4bstpB+QFt0p2oauMrsjVbUamGWQ6YNavh7x2em2uZlzV44g==",
-      "license": "MIT",
-      "dependencies": {
-        "dagre": "^0.8.5"
-      },
-      "peerDependencies": {
-        "cytoscape": "^3.2.22"
-      }
-    },
-    "node_modules/dagre": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/dagre/-/dagre-0.8.5.tgz",
-      "integrity": "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==",
-      "license": "MIT",
-      "dependencies": {
-        "graphlib": "^2.1.8",
-        "lodash": "^4.17.15"
-      }
-    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1458,15 +1419,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/graphlib": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
-      "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.15"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1498,12 +1450,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -1736,6 +1682,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/svg-pan-zoom": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/svg-pan-zoom/-/svg-pan-zoom-3.6.2.tgz",
+      "integrity": "sha512-JwnvRWfVKw/Xzfe6jriFyfey/lWJLq4bUh2jwoR5ChWQuQoOH8FEh1l/bEp46iHHKHEJWIyFJETbazraxNWECg==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/ui/client/package-lock.json
+++ b/ui/client/package-lock.json
@@ -13,7 +13,6 @@
         "cytoscape": "^3.33.2",
         "cytoscape-dagre": "^2.5.0",
         "react": "^18.3.1",
-        "react-cytoscapejs": "^2.0.0",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.23.1"
       },
@@ -1561,15 +1560,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1606,17 +1596,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -1627,19 +1606,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-cytoscapejs": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/react-cytoscapejs/-/react-cytoscapejs-2.0.0.tgz",
-      "integrity": "sha512-t3SSl1DQy7+JQjN+8QHi1anEJlM3i3aAeydHTsJwmjo/isyKK7Rs7oCvU6kZsB9NwZidzZQR21Vm2PcBLG/Tjg==",
-      "license": "MIT",
-      "dependencies": {
-        "prop-types": "^15.8.1"
-      },
-      "peerDependencies": {
-        "cytoscape": "^3.2.19",
-        "react": ">=15.0.0"
       }
     },
     "node_modules/react-dom": {
@@ -1654,12 +1620,6 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
-    },
-    "node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",

--- a/ui/client/package.json
+++ b/ui/client/package.json
@@ -13,7 +13,6 @@
     "cytoscape": "^3.33.2",
     "cytoscape-dagre": "^2.5.0",
     "react": "^18.3.1",
-    "react-cytoscapejs": "^2.0.0",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.23.1"
   },

--- a/ui/client/package.json
+++ b/ui/client/package.json
@@ -9,12 +9,10 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.40.0",
-    "@types/cytoscape": "^3.21.9",
-    "cytoscape": "^3.33.2",
-    "cytoscape-dagre": "^2.5.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.23.1"
+    "react-router-dom": "^6.23.1",
+    "svg-pan-zoom": "^3.6.2"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/ui/client/package.json
+++ b/ui/client/package.json
@@ -9,7 +9,11 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.40.0",
+    "@types/cytoscape": "^3.21.9",
+    "cytoscape": "^3.33.2",
+    "cytoscape-dagre": "^2.5.0",
     "react": "^18.3.1",
+    "react-cytoscapejs": "^2.0.0",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.23.1"
   },

--- a/ui/client/src/App.tsx
+++ b/ui/client/src/App.tsx
@@ -2,6 +2,7 @@ import { Routes, Route, NavLink, Navigate } from 'react-router-dom';
 import { useProject } from './hooks/useApi';
 import Overview from './views/Overview';
 import LogViewer from './views/LogViewer';
+import Nodes from './views/Nodes';
 
 function ConnectionBanner({ isError }: { isError: boolean }) {
   if (!isError) return null;
@@ -26,13 +27,17 @@ export default function App() {
         <h1>KIP</h1>
         {project && <span className="project-badge" title={project.path}>{project.name}</span>}
         <nav className="header-nav">
-          <NavLink to="/" className={({ isActive }) => `nav-link ${isActive ? 'active' : ''}`} end>Overview</NavLink>
+          <NavLink to="/" className={({ isActive }) => `nav-link ${isActive ? 'active' : ''}`} end>Nodes</NavLink>
+          <NavLink to="/overview" className={({ isActive }) => `nav-link ${isActive ? 'active' : ''}`}>Overview</NavLink>
           <NavLink to="/logs" className={({ isActive }) => `nav-link ${isActive ? 'active' : ''}`}>Logs</NavLink>
         </nav>
       </header>
       <main className="main-content">
         <Routes>
-          <Route path="/" element={<Overview />} />
+          <Route path="/" element={<Nodes />} />
+          <Route path="/nodes" element={<Nodes />} />
+          <Route path="/nodes/:id" element={<Nodes />} />
+          <Route path="/overview" element={<Overview />} />
           <Route path="/logs" element={<LogViewer />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>

--- a/ui/client/src/components/NodeDetail.module.css
+++ b/ui/client/src/components/NodeDetail.module.css
@@ -75,9 +75,8 @@
   border-radius: 3px;
 }
 .refLine a { cursor: pointer; }
-.refConfirmed { color: var(--text-secondary); }
-.refUnconfirmed { color: var(--text-muted); }
-.refUnconfirmed::after { content: ' (unconfirmed)'; font-size: 10px; }
+.refLink { color: var(--text-secondary); }
+.refLink:hover { color: var(--blue); }
 
 .empty { color: var(--text-muted); font-size: 11px; font-style: italic; }
 

--- a/ui/client/src/components/NodeDetail.module.css
+++ b/ui/client/src/components/NodeDetail.module.css
@@ -236,6 +236,51 @@ details[open] > summary.sectionLabel { margin-bottom: 6px; }
 .leanRow { display: flex; justify-content: space-between; padding: 2px 0; }
 .leanRow .leanKey { color: var(--text-muted); }
 .leanRow .leanVal { font-family: var(--font-mono); font-size: 11px; color: var(--text-primary); }
+
+/* Lean source span. Same look-and-feel as .excerpt but a bit taller and with
+   horizontal scroll instead of wrap — Lean declarations exceed 80 columns
+   often, and wrapping mid-arrow makes alignment review harder than scroll. */
+.leanSource {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  white-space: pre;
+  background: var(--bg-secondary);
+  padding: 8px 10px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  margin-top: 8px;
+  max-height: 360px;
+  overflow: auto;
+  line-height: 1.45;
+  color: var(--text-primary);
+  tab-size: 2;
+}
+/* Lightweight Lean syntax colours — see ../utils/leanHighlight.ts. The
+   palette mirrors github-light tokens so it's legible on var(--bg-secondary)
+   and doesn't clash with the surrounding chrome. */
+.leanSource :global(.lean-c) { color: #6a737d; font-style: italic; }
+.leanSource :global(.lean-s) { color: #032f62; }
+.leanSource :global(.lean-a) { color: #6f42c1; }
+.leanSource :global(.lean-k) { color: #d73a49; }
+.leanSource :global(.lean-n) { color: #005cc5; }
+
+/* Small "beta" pill next to the Lean declaration label — flags that the
+   source slicing + highlighting are regex-based, not a real Lean parser, so
+   reviewers know to spot-check rather than trust the preview blindly. */
+.betaBadge {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 6px;
+  border-radius: 8px;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #ffffff;
+  background: #e36209;  /* orange — matches the "aligned" phase chip palette */
+  vertical-align: 2px;
+  cursor: help;
+}
 .sorryDot {
   display: inline-block;
   width: 8px; height: 8px;

--- a/ui/client/src/components/NodeDetail.module.css
+++ b/ui/client/src/components/NodeDetail.module.css
@@ -1,0 +1,180 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.header {
+  padding: 14px 16px 10px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-secondary);
+}
+.idRow { display: flex; align-items: baseline; gap: 8px; margin-bottom: 4px; }
+.id { font-family: var(--font-mono); font-size: 13px; font-weight: 500; color: var(--text-primary); word-break: break-all; }
+.kindChip {
+  font-size: 10px; text-transform: uppercase; letter-spacing: 0.04em;
+  padding: 2px 6px; border-radius: 3px;
+  background: var(--bg-tertiary); color: var(--text-secondary);
+}
+.subline { font-size: 11px; color: var(--text-muted); }
+.subline a { color: var(--blue); }
+
+.phaseBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  margin-top: 8px;
+  padding: 3px 8px;
+  border-radius: 3px;
+  font-weight: 500;
+  color: white;
+}
+
+.section {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+}
+.sectionLabel {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+  font-weight: 600;
+}
+
+.flagsGrid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 4px;
+}
+.flag {
+  text-align: center;
+  padding: 6px 4px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: var(--bg-secondary);
+  font-size: 10px;
+  color: var(--text-muted);
+}
+.flagOn {
+  background: rgba(40,167,69,0.1);
+  border-color: var(--green);
+  color: var(--green);
+}
+.flagMark { font-size: 14px; line-height: 1; }
+.flagText { display: block; margin-top: 2px; }
+
+.refLine { font-size: 12px; padding: 2px 0; }
+.refLine code {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  background: var(--bg-tertiary);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+.refLine a { cursor: pointer; }
+.refConfirmed { color: var(--text-secondary); }
+.refUnconfirmed { color: var(--text-muted); }
+.refUnconfirmed::after { content: ' (unconfirmed)'; font-size: 10px; }
+
+.empty { color: var(--text-muted); font-size: 11px; font-style: italic; }
+
+.excerpt {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  white-space: pre-wrap;
+  background: var(--bg-secondary);
+  padding: 8px 10px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  max-height: 240px;
+  overflow-y: auto;
+  line-height: 1.4;
+  color: var(--text-primary);
+}
+
+/* Rendered LaTeX block (HTML extracted from blueprint/web/sec-*.html;
+   MathJax v3 typesets the \(...\) and \[...\] markers in place). */
+.rendered {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  line-height: 1.55;
+  background: var(--bg-secondary);
+  padding: 10px 14px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  max-height: 360px;
+  overflow-y: auto;
+  color: var(--text-primary);
+}
+.rendered p { margin: 0.4em 0; }
+.rendered ol, .rendered ul { margin: 0.4em 0 0.4em 1.4em; }
+.rendered li { margin: 0.2em 0; }
+.rendered .displaymath {
+  text-align: center;
+  margin: 0.6em 0;
+  overflow-x: auto;
+}
+.rendered em { font-style: italic; color: var(--text-primary); }
+.rendered code, .rendered pre {
+  font-family: var(--font-mono);
+  font-size: 0.92em;
+  background: var(--bg-tertiary);
+  padding: 1px 4px;
+  border-radius: 2px;
+}
+.rendered a { color: var(--blue); pointer-events: none; }  /* dead links to chapter pages */
+.rendered img { max-width: 100%; height: auto; }
+.rendered :global(mjx-container) { overflow-x: auto; overflow-y: hidden; }
+
+.leanBox {
+  font-size: 12px;
+  background: var(--bg-secondary);
+  padding: 8px 10px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+}
+.leanRow { display: flex; justify-content: space-between; padding: 2px 0; }
+.leanRow .leanKey { color: var(--text-muted); }
+.leanRow .leanVal { font-family: var(--font-mono); font-size: 11px; color: var(--text-primary); }
+.sorryDot {
+  display: inline-block;
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  margin-right: 4px;
+}
+.sorryDot.green { background: var(--green); }
+.sorryDot.orange { background: var(--orange); }
+
+.commentsList { display: flex; flex-direction: column; gap: 8px; }
+.commentItem {
+  border-left: 2px solid var(--border);
+  padding: 4px 0 4px 8px;
+}
+.commentMeta { font-size: 10px; color: var(--text-muted); margin-bottom: 2px; }
+.commentTopic {
+  font-size: 9px; text-transform: uppercase; letter-spacing: 0.05em;
+  padding: 1px 4px; border-radius: 2px;
+  background: var(--bg-tertiary); color: var(--text-secondary);
+  margin-right: 6px;
+}
+.commentText { font-size: 12px; color: var(--text-primary); white-space: pre-wrap; }
+
+.runsList { display: flex; flex-direction: column; gap: 6px; }
+.runItem {
+  font-size: 11px;
+  padding: 6px 8px;
+  border-radius: 3px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+}
+.runHeader { display: flex; justify-content: space-between; align-items: baseline; gap: 6px; }
+.runAgent { font-weight: 500; }
+.runStatus { font-size: 10px; padding: 1px 5px; border-radius: 2px; }
+.runStatus.done { background: rgba(40,167,69,0.12); color: var(--green); }
+.runStatus.running { background: rgba(3,102,214,0.12); color: var(--blue); }
+.runStatus.error { background: rgba(203,36,49,0.12); color: var(--red); }
+.runMeta { color: var(--text-muted); font-size: 10px; margin-top: 2px; font-variant-numeric: tabular-nums; }
+.runHint { color: var(--text-secondary); font-size: 10px; font-family: var(--font-mono); margin-top: 2px; word-break: break-all; }

--- a/ui/client/src/components/NodeDetail.module.css
+++ b/ui/client/src/components/NodeDetail.module.css
@@ -43,6 +43,16 @@
   margin-bottom: 6px;
   font-weight: 600;
 }
+/* When the section is a <details>/<summary> (collapsible Uses / Used by /
+   Agent runs), the summary needs to feel clickable and keep no extra bottom
+   gap when collapsed. The native disclosure triangle stays. */
+summary.sectionLabel {
+  cursor: pointer;
+  user-select: none;
+  margin-bottom: 0;
+}
+summary.sectionLabel:hover { color: var(--text-secondary); }
+details[open] > summary.sectionLabel { margin-bottom: 6px; }
 
 .flagsGrid {
   display: grid;
@@ -65,6 +75,94 @@
 }
 .flagMark { font-size: 14px; line-height: 1; }
 .flagText { display: block; margin-top: 2px; }
+
+.attribution {
+  margin-top: 8px;
+  font-size: 11px;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+.attribution b {
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.reviewHint {
+  font-size: 11px;
+  color: var(--text-muted);
+  line-height: 1.45;
+  margin-bottom: 8px;
+}
+.reviewForm {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.reviewerLabel {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.reviewerInput {
+  flex: 1;
+  font-size: 12px;
+  padding: 4px 6px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font-family: inherit;
+  text-transform: none;
+  letter-spacing: normal;
+}
+.reviewerInput:focus {
+  outline: none;
+  border-color: var(--blue);
+}
+.reviewCommentBox {
+  font-size: 12px;
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font-family: inherit;
+  resize: vertical;
+  min-height: 38px;
+}
+.reviewCommentBox:focus {
+  outline: none;
+  border-color: var(--blue);
+}
+.reviewBtn {
+  align-self: flex-start;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  color: white;
+  background: var(--green);
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+}
+.reviewBtn:hover:not(:disabled) { filter: brightness(1.06); }
+.reviewBtn:disabled {
+  background: var(--bg-tertiary);
+  color: var(--text-muted);
+  cursor: not-allowed;
+}
+.reviewError {
+  font-size: 11px;
+  color: var(--red);
+}
+.reviewOk {
+  font-size: 11px;
+  color: var(--green);
+}
 
 .refLine { font-size: 12px; padding: 2px 0; }
 .refLine code {

--- a/ui/client/src/components/NodeDetail.tsx
+++ b/ui/client/src/components/NodeDetail.tsx
@@ -3,6 +3,7 @@ import { useNode, useReviewAction, type ReviewAction } from '../hooks/useApi';
 import { PHASE_COLORS, PHASE_LABELS } from '../utils/constants';
 import { fmtDuration } from '../utils/format';
 import { typesetMath } from '../utils/mathjax';
+import { highlightLean } from '../utils/leanHighlight';
 import type { NodeDetail as NodeDetailT, NodeFlags } from '../types';
 import styles from './NodeDetail.module.css';
 
@@ -239,7 +240,17 @@ export default function NodeDetail({ nodeId, onClose, onSelectNode }: Props) {
 
       {d.leanDecl && (
         <div className={styles.section}>
-          <div className={styles.sectionLabel}>Lean declaration</div>
+          <div className={styles.sectionLabel}>
+            Lean declaration
+            <span
+              className={styles.betaBadge}
+              title={'Source slice + highlighting are regex-based, not a real Lean parser. ' +
+                     'Boundaries follow next-decl-heading; nested block comments and unicode ' +
+                     'identifiers may render imperfectly.'}
+            >
+              beta
+            </span>
+          </div>
           <div className={styles.leanBox}>
             <div className={styles.leanRow}>
               <span className={styles.leanKey}>name</span>
@@ -257,6 +268,16 @@ export default function NodeDetail({ nodeId, onClose, onSelectNode }: Props) {
               </span>
             </div>
           </div>
+          {d.leanSource ? (
+            <pre
+              className={styles.leanSource}
+              dangerouslySetInnerHTML={{ __html: highlightLean(d.leanSource) }}
+            />
+          ) : (
+            <div className={styles.empty}>
+              source unavailable (file moved or out-of-range — rebuild state.db)
+            </div>
+          )}
         </div>
       )}
       {d.leanDecl == null && d.leanDecl !== undefined && d.flags.bound && (

--- a/ui/client/src/components/NodeDetail.tsx
+++ b/ui/client/src/components/NodeDetail.tsx
@@ -1,10 +1,12 @@
-import { useEffect, useRef } from 'react';
-import { useNode } from '../hooks/useApi';
+import { useEffect, useRef, useState } from 'react';
+import { useNode, useReviewAction, type ReviewAction } from '../hooks/useApi';
 import { PHASE_COLORS, PHASE_LABELS } from '../utils/constants';
 import { fmtDuration } from '../utils/format';
 import { typesetMath } from '../utils/mathjax';
 import type { NodeDetail as NodeDetailT, NodeFlags } from '../types';
 import styles from './NodeDetail.module.css';
+
+const REVIEWER_STORAGE_KEY = 'kip:reviewer';
 
 const FLAG_DISPLAY: { key: keyof NodeFlags; label: string }[] = [
   { key: 'nlReviewed', label: 'NL'     },
@@ -13,20 +15,46 @@ const FLAG_DISPLAY: { key: keyof NodeFlags; label: string }[] = [
   { key: 'proved',     label: 'Proved' },
 ];
 
+// Render an `at` value in Beijing time. Date-only legacy entries pass through
+// unchanged (already read as 'YYYY-MM-DD'); full ISO datetimes are formatted
+// as 'YYYY-MM-DD HH:mm' in Asia/Shanghai. `sv-SE` locale gives an unambiguous,
+// ISO-shaped output.
+const beijingFmt = new Intl.DateTimeFormat('sv-SE', {
+  timeZone: 'Asia/Shanghai',
+  year: 'numeric', month: '2-digit', day: '2-digit',
+  hour: '2-digit', minute: '2-digit', hour12: false,
+});
+function fmtAt(iso: string | null | undefined): string {
+  if (!iso) return '';
+  if (!iso.includes('T')) return iso;
+  const t = Date.parse(iso);
+  if (isNaN(t)) return iso;
+  return beijingFmt.format(new Date(t));
+}
+
+// Show a relative time when we have a precise instant, otherwise fall back to
+// the date string as-is. Date-only legacy entries (like '2026-04-19') lack
+// time information — guessing midnight in *any* zone is a lie that misleads
+// users by 8–16h, so we just show the date and let them eyeball recency.
 function fmtRelTime(iso: string | null | undefined): string {
   if (!iso) return '';
+  if (!iso.includes('T')) return iso;
   const t = Date.parse(iso);
   if (isNaN(t)) return iso;
   const diff = Date.now() - t;
-  if (diff < 0) return new Date(t).toLocaleString();
+  if (diff < 0) return fmtAt(iso);
   const s = Math.floor(diff / 1000);
+  if (s < 5) return 'just now';
   if (s < 60) return `${s}s ago`;
   const m = Math.floor(s / 60);
   if (m < 60) return `${m}m ago`;
   const h = Math.floor(m / 60);
   if (h < 48) return `${h}h ago`;
   const d = Math.floor(h / 24);
-  return `${d}d ago`;
+  // Beyond 72h, "Nd ago" loses the precision needed to compare two old
+  // comments — show the absolute Beijing-time stamp instead.
+  if (d < 3) return `${d}d ago`;
+  return fmtAt(iso);
 }
 
 interface Props {
@@ -38,6 +66,36 @@ interface Props {
 export default function NodeDetail({ nodeId, onClose, onSelectNode }: Props) {
   const { data, isLoading, isError } = useNode(nodeId);
   const renderedRef = useRef<HTMLDivElement | null>(null);
+
+  const [reviewer, setReviewer] = useState<string>(() =>
+    (typeof window !== 'undefined' && window.localStorage.getItem(REVIEWER_STORAGE_KEY)) || ''
+  );
+  const [reviewComment, setReviewComment] = useState<string>('');
+  const review = useReviewAction();
+
+  // Persist reviewer across reloads (also across drawer reopens for the same
+  // browser session). We trim before storing so stray spaces don't follow.
+  useEffect(() => {
+    const v = reviewer.trim();
+    if (v) window.localStorage.setItem(REVIEWER_STORAGE_KEY, v);
+  }, [reviewer]);
+
+  // Clear the comment box and mutation state when switching nodes — comments
+  // are scoped to a specific approval, never carried across.
+  useEffect(() => {
+    setReviewComment('');
+    review.reset();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nodeId]);
+
+  // Same reset after a successful submit — but keep the reviewer name.
+  useEffect(() => {
+    if (review.isSuccess) {
+      setReviewComment('');
+      const t = setTimeout(() => review.reset(), 1500);
+      return () => clearTimeout(t);
+    }
+  }, [review.isSuccess, review]);
 
   useEffect(() => {
     // re-run MathJax whenever the rendered block changes
@@ -99,7 +157,85 @@ export default function NodeDetail({ nodeId, onClose, onSelectNode }: Props) {
             );
           })}
         </div>
+        {(d.nlReviewer || d.alignReviewer) && (
+          <div className={styles.attribution}>
+            {d.nlReviewer && (
+              <div>NL reviewed by <b>{d.nlReviewer}</b></div>
+            )}
+            {d.alignReviewer && (
+              <div>
+                Aligned by <b>{d.alignReviewer}</b>
+                {d.alignedAt ? ` · ${fmtAt(d.alignedAt)}` : ''}
+              </div>
+            )}
+          </div>
+        )}
       </div>
+
+      {(() => {
+        const canApproveNL = !d.flags.nlReviewed;
+        const canConfirmAlign = d.flags.nlReviewed && d.flags.bound && !d.flags.aligned;
+        if (!canApproveNL && !canConfirmAlign) return null;
+        const action: ReviewAction = canApproveNL ? 'approve_nl' : 'confirm_alignment';
+        const title = canApproveNL ? 'Approve NL' : 'Confirm alignment';
+        const hint = canApproveNL
+          ? 'Confirm the natural-language statement is correct as written. This advances phase from drafted → nl_reviewed.'
+          : 'Confirm the Lean declaration faithfully formalizes the NL statement. Advances phase from bound → aligned.';
+        const placeholder = canApproveNL
+          ? 'optional: notes for the review log (e.g. "matches §3.2 wording")'
+          : 'optional: alignment notes (e.g. "types match, p/q convention as in NL")';
+        const reviewerOk = reviewer.trim().length > 0;
+        const submit = (e: React.FormEvent) => {
+          e.preventDefault();
+          if (!reviewerOk || review.isPending) return;
+          review.mutate({
+            nodeId: d.id,
+            action,
+            reviewer: reviewer.trim(),
+            comment: reviewComment.trim() || undefined,
+          });
+        };
+        return (
+          <div className={styles.section}>
+            <div className={styles.sectionLabel}>Review</div>
+            <div className={styles.reviewHint}>{hint}</div>
+            <form className={styles.reviewForm} onSubmit={submit}>
+              <label className={styles.reviewerLabel}>
+                Reviewing as
+                <input
+                  type="text"
+                  className={styles.reviewerInput}
+                  placeholder="your name"
+                  value={reviewer}
+                  onChange={e => setReviewer(e.target.value)}
+                />
+              </label>
+              <textarea
+                className={styles.reviewCommentBox}
+                placeholder={placeholder}
+                value={reviewComment}
+                onChange={e => setReviewComment(e.target.value)}
+                rows={2}
+              />
+              <button
+                type="submit"
+                className={styles.reviewBtn}
+                disabled={!reviewerOk || review.isPending}
+              >
+                {review.isPending ? 'Submitting…' : title}
+              </button>
+              {review.isError && (
+                <div className={styles.reviewError}>
+                  {(review.error as Error)?.message || 'Submit failed'}
+                </div>
+              )}
+              {review.isSuccess && (
+                <div className={styles.reviewOk}>✓ Recorded</div>
+              )}
+            </form>
+          </div>
+        );
+      })()}
 
       {d.leanDecl && (
         <div className={styles.section}>
@@ -149,8 +285,8 @@ export default function NodeDetail({ nodeId, onClose, onSelectNode }: Props) {
         </div>
       ) : null}
 
-      <div className={styles.section}>
-        <div className={styles.sectionLabel}>Uses ({d.uses.length})</div>
+      <details className={styles.section}>
+        <summary className={styles.sectionLabel}>Uses ({d.uses.length})</summary>
         {d.uses.length === 0 ? <div className={styles.empty}>No outgoing dependencies.</div> :
           d.uses.map(e => (
             <div key={e.id} className={styles.refLine}>
@@ -160,10 +296,10 @@ export default function NodeDetail({ nodeId, onClose, onSelectNode }: Props) {
             </div>
           ))
         }
-      </div>
+      </details>
 
-      <div className={styles.section}>
-        <div className={styles.sectionLabel}>Used by ({d.usedBy.length})</div>
+      <details className={styles.section}>
+        <summary className={styles.sectionLabel}>Used by ({d.usedBy.length})</summary>
         {d.usedBy.length === 0 ? <div className={styles.empty}>Leaf node (nothing uses this).</div> :
           d.usedBy.map(e => (
             <div key={e.id} className={styles.refLine}>
@@ -173,7 +309,7 @@ export default function NodeDetail({ nodeId, onClose, onSelectNode }: Props) {
             </div>
           ))
         }
-      </div>
+      </details>
 
       <div className={styles.section}>
         <div className={styles.sectionLabel}>Comments ({d.comments.length})</div>
@@ -183,7 +319,7 @@ export default function NodeDetail({ nodeId, onClose, onSelectNode }: Props) {
               <div key={c.idx} className={styles.commentItem}>
                 <div className={styles.commentMeta}>
                   {c.topic && <span className={styles.commentTopic}>{c.topic}</span>}
-                  <span>{c.by || 'anonymous'}{c.at ? ` · ${c.at}` : ''}</span>
+                  <span>{c.by || 'anonymous'}{c.at ? ` · ${fmtAt(c.at)}` : ''}</span>
                 </div>
                 <div className={styles.commentText}>{c.text}</div>
               </div>
@@ -192,8 +328,8 @@ export default function NodeDetail({ nodeId, onClose, onSelectNode }: Props) {
         }
       </div>
 
-      <div className={styles.section}>
-        <div className={styles.sectionLabel}>Agent runs touching this node ({d.runs.length})</div>
+      <details className={styles.section}>
+        <summary className={styles.sectionLabel}>Agent runs touching this node ({d.runs.length})</summary>
         {d.runs.length === 0 ? <div className={styles.empty}>No agent runs reference this node.</div> :
           <div className={styles.runsList}>
             {d.runs.map(r => {
@@ -217,7 +353,7 @@ export default function NodeDetail({ nodeId, onClose, onSelectNode }: Props) {
             })}
           </div>
         }
-      </div>
+      </details>
     </div>
   );
 }

--- a/ui/client/src/components/NodeDetail.tsx
+++ b/ui/client/src/components/NodeDetail.tsx
@@ -154,8 +154,9 @@ export default function NodeDetail({ nodeId, onClose, onSelectNode }: Props) {
         {d.uses.length === 0 ? <div className={styles.empty}>No outgoing dependencies.</div> :
           d.uses.map(e => (
             <div key={e.id} className={styles.refLine}>
-              <a className={e.confirmed ? styles.refConfirmed : styles.refUnconfirmed}
-                 onClick={() => onSelectNode(e.id)}><code>{e.id}</code></a>
+              <a className={styles.refLink} onClick={() => onSelectNode(e.id)}>
+                <code>{e.id}</code>
+              </a>
             </div>
           ))
         }
@@ -166,8 +167,9 @@ export default function NodeDetail({ nodeId, onClose, onSelectNode }: Props) {
         {d.usedBy.length === 0 ? <div className={styles.empty}>Leaf node (nothing uses this).</div> :
           d.usedBy.map(e => (
             <div key={e.id} className={styles.refLine}>
-              <a className={e.confirmed ? styles.refConfirmed : styles.refUnconfirmed}
-                 onClick={() => onSelectNode(e.id)}><code>{e.id}</code></a>
+              <a className={styles.refLink} onClick={() => onSelectNode(e.id)}>
+                <code>{e.id}</code>
+              </a>
             </div>
           ))
         }

--- a/ui/client/src/components/NodeDetail.tsx
+++ b/ui/client/src/components/NodeDetail.tsx
@@ -1,0 +1,221 @@
+import { useEffect, useRef } from 'react';
+import { useNode } from '../hooks/useApi';
+import { PHASE_COLORS, PHASE_LABELS } from '../utils/constants';
+import { fmtDuration } from '../utils/format';
+import { typesetMath } from '../utils/mathjax';
+import type { NodeDetail as NodeDetailT, NodeFlags } from '../types';
+import styles from './NodeDetail.module.css';
+
+const FLAG_DISPLAY: { key: keyof NodeFlags; label: string }[] = [
+  { key: 'nlReviewed', label: 'NL'     },
+  { key: 'bound',      label: 'Bound'  },
+  { key: 'aligned',    label: 'Align'  },
+  { key: 'proved',     label: 'Proved' },
+];
+
+function fmtRelTime(iso: string | null | undefined): string {
+  if (!iso) return '';
+  const t = Date.parse(iso);
+  if (isNaN(t)) return iso;
+  const diff = Date.now() - t;
+  if (diff < 0) return new Date(t).toLocaleString();
+  const s = Math.floor(diff / 1000);
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 48) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  return `${d}d ago`;
+}
+
+interface Props {
+  nodeId: string;
+  onClose: () => void;
+  onSelectNode: (id: string) => void;
+}
+
+export default function NodeDetail({ nodeId, onClose, onSelectNode }: Props) {
+  const { data, isLoading, isError } = useNode(nodeId);
+  const renderedRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    // re-run MathJax whenever the rendered block changes
+    typesetMath(renderedRef.current);
+  }, [data?.nlRendered?.contentHtml]);
+
+  if (isLoading) {
+    return <div className={styles.root}><div className={styles.section}>Loading…</div></div>;
+  }
+  if (isError || !data) {
+    return (
+      <div className={styles.root}>
+        <div className={styles.header}>
+          <div className={styles.idRow}>
+            <span className={styles.id}>{nodeId}</span>
+            <button onClick={onClose} style={{ marginLeft: 'auto', cursor: 'pointer', border: 'none', background: 'transparent', fontSize: 16, color: 'var(--text-muted)' }}>×</button>
+          </div>
+        </div>
+        <div className={styles.section}>Node not found in index. Try re-running <code>python tools/kip-state/index.py</code>.</div>
+      </div>
+    );
+  }
+
+  const d = data as NodeDetailT;
+  const phaseColor = PHASE_COLORS[d.phase] || '#999';
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.header}>
+        <div className={styles.idRow}>
+          <span className={styles.id}>{d.id}</span>
+          <button onClick={onClose}
+                  style={{ marginLeft: 'auto', cursor: 'pointer', border: 'none', background: 'transparent', fontSize: 18, color: 'var(--text-muted)', lineHeight: 1 }}
+                  aria-label="Close">×</button>
+        </div>
+        <div className={styles.subline}>
+          {d.kind && <span className={styles.kindChip}>{d.kind}</span>}{' '}
+          {d.chapter && <span>· {d.chapter}</span>}
+          {d.sourceFile && d.sourceLine != null && (
+            <span> · {d.sourceFile.split('/').slice(-1)[0]}:{d.sourceLine}</span>
+          )}
+        </div>
+        <div className={styles.phaseBadge} style={{ background: phaseColor }}>
+          {PHASE_LABELS[d.phase] || d.phase}
+          {d.lastActivity && <span style={{ opacity: 0.85, fontSize: 11, fontWeight: 400 }}>· {fmtRelTime(d.lastActivity)}</span>}
+        </div>
+      </div>
+
+      <div className={styles.section}>
+        <div className={styles.sectionLabel}>Lifecycle</div>
+        <div className={styles.flagsGrid}>
+          {FLAG_DISPLAY.map(f => {
+            const on = d.flags[f.key];
+            return (
+              <div key={f.key} className={`${styles.flag} ${on ? styles.flagOn : ''}`}>
+                <span className={styles.flagMark}>{on ? '✓' : '·'}</span>
+                <span className={styles.flagText}>{f.label}</span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {d.leanDecl && (
+        <div className={styles.section}>
+          <div className={styles.sectionLabel}>Lean declaration</div>
+          <div className={styles.leanBox}>
+            <div className={styles.leanRow}>
+              <span className={styles.leanKey}>name</span>
+              <span className={styles.leanVal}>{d.leanDecl.name}</span>
+            </div>
+            <div className={styles.leanRow}>
+              <span className={styles.leanKey}>file</span>
+              <span className={styles.leanVal}>{d.leanDecl.file}:{d.leanDecl.line_start}</span>
+            </div>
+            <div className={styles.leanRow}>
+              <span className={styles.leanKey}>sorry</span>
+              <span className={styles.leanVal}>
+                <span className={`${styles.sorryDot} ${d.leanDecl.sorry_count === 0 ? styles.green : styles.orange}`}></span>
+                {d.leanDecl.sorry_count}
+              </span>
+            </div>
+          </div>
+        </div>
+      )}
+      {d.leanDecl == null && d.leanDecl !== undefined && d.flags.bound && (
+        <div className={styles.section}>
+          <div className={styles.sectionLabel}>Lean declaration</div>
+          <div className={styles.empty}>Marked bound, but no matching declaration in KIP/. Likely external (mathlib) or stale.</div>
+        </div>
+      )}
+
+      {d.nlRendered ? (
+        <div className={styles.section}>
+          <div className={styles.sectionLabel}>
+            {d.nlRendered.caption || d.kind || 'NL'}
+            {d.nlRendered.label && <> · {d.nlRendered.label}</>}
+          </div>
+          <div
+            ref={renderedRef}
+            className={styles.rendered}
+            dangerouslySetInnerHTML={{ __html: d.nlRendered.contentHtml }}
+          />
+        </div>
+      ) : d.nlExcerpt ? (
+        <div className={styles.section}>
+          <div className={styles.sectionLabel}>NL source ({d.kind}) — raw, no rendered HTML found</div>
+          <pre className={styles.excerpt}>{d.nlExcerpt}</pre>
+        </div>
+      ) : null}
+
+      <div className={styles.section}>
+        <div className={styles.sectionLabel}>Uses ({d.uses.length})</div>
+        {d.uses.length === 0 ? <div className={styles.empty}>No outgoing dependencies.</div> :
+          d.uses.map(e => (
+            <div key={e.id} className={styles.refLine}>
+              <a className={e.confirmed ? styles.refConfirmed : styles.refUnconfirmed}
+                 onClick={() => onSelectNode(e.id)}><code>{e.id}</code></a>
+            </div>
+          ))
+        }
+      </div>
+
+      <div className={styles.section}>
+        <div className={styles.sectionLabel}>Used by ({d.usedBy.length})</div>
+        {d.usedBy.length === 0 ? <div className={styles.empty}>Leaf node (nothing uses this).</div> :
+          d.usedBy.map(e => (
+            <div key={e.id} className={styles.refLine}>
+              <a className={e.confirmed ? styles.refConfirmed : styles.refUnconfirmed}
+                 onClick={() => onSelectNode(e.id)}><code>{e.id}</code></a>
+            </div>
+          ))
+        }
+      </div>
+
+      <div className={styles.section}>
+        <div className={styles.sectionLabel}>Comments ({d.comments.length})</div>
+        {d.comments.length === 0 ? <div className={styles.empty}>No comments yet.</div> :
+          <div className={styles.commentsList}>
+            {d.comments.map(c => (
+              <div key={c.idx} className={styles.commentItem}>
+                <div className={styles.commentMeta}>
+                  {c.topic && <span className={styles.commentTopic}>{c.topic}</span>}
+                  <span>{c.by || 'anonymous'}{c.at ? ` · ${c.at}` : ''}</span>
+                </div>
+                <div className={styles.commentText}>{c.text}</div>
+              </div>
+            ))}
+          </div>
+        }
+      </div>
+
+      <div className={styles.section}>
+        <div className={styles.sectionLabel}>Agent runs touching this node ({d.runs.length})</div>
+        {d.runs.length === 0 ? <div className={styles.empty}>No agent runs reference this node.</div> :
+          <div className={styles.runsList}>
+            {d.runs.map(r => {
+              const status = (r.status || 'unknown').toLowerCase();
+              const statusClass = status === 'done' ? styles.done : status === 'running' ? styles.running : styles.error;
+              return (
+                <div key={r.id} className={styles.runItem}>
+                  <div className={styles.runHeader}>
+                    <span className={styles.runAgent}>{r.agent} · {r.model || '—'}</span>
+                    <span className={`${styles.runStatus} ${statusClass}`}>{r.status || 'unknown'}</span>
+                  </div>
+                  <div className={styles.runMeta}>
+                    {r.completed_at ? fmtRelTime(r.completed_at) : (r.started_at ? `started ${fmtRelTime(r.started_at)}` : '')}
+                    {r.duration_ms ? ` · ${fmtDuration(r.duration_ms)}` : ''}
+                    {r.cost_usd != null ? ` · $${r.cost_usd.toFixed(2)}` : ''}
+                    {r.num_turns ? ` · ${r.num_turns} turns` : ''}
+                  </div>
+                  {r.hint_file && <div className={styles.runHint}>{r.hint_file}</div>}
+                </div>
+              );
+            })}
+          </div>
+        }
+      </div>
+    </div>
+  );
+}

--- a/ui/client/src/hooks/useApi.ts
+++ b/ui/client/src/hooks/useApi.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiUrl } from '../utils/constants';
 import type {
   LogEntry, AggregatedStats, LogsResponse, AgentSummary,
@@ -57,6 +57,45 @@ export function useNode(id: string) {
     queryKey: ['node', id],
     queryFn: () => fetchJson(`/api/nodes/${encodeURIComponent(id)}`),
     enabled: !!id,
+  });
+}
+
+export type ReviewAction = 'approve_nl' | 'confirm_alignment';
+
+export interface ReviewVars {
+  nodeId: string;
+  action: ReviewAction;
+  reviewer: string;
+  comment?: string;
+}
+
+export function useReviewAction() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (vars: ReviewVars) => {
+      const res = await fetch(apiUrl(`/api/nodes/${encodeURIComponent(vars.nodeId)}/review`), {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          action: vars.action,
+          reviewer: vars.reviewer,
+          comment: vars.comment || undefined,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `API ${res.status}`);
+      }
+      return res.json() as Promise<{ ok: true; id: string; action: ReviewAction; reviewer: string; at: string }>;
+    },
+    onSuccess: (_data, vars) => {
+      // Phase changed — refresh the node detail and the graph payload (which
+      // drives the SVG, sidebar phase counts, and chip filters).
+      qc.invalidateQueries({ queryKey: ['node', vars.nodeId] });
+      qc.invalidateQueries({ queryKey: ['graph'] });
+      qc.invalidateQueries({ queryKey: ['graph-svg'] });
+      qc.invalidateQueries({ queryKey: ['stateHealth'] });
+    },
   });
 }
 

--- a/ui/client/src/hooks/useApi.ts
+++ b/ui/client/src/hooks/useApi.ts
@@ -67,3 +67,27 @@ export function useStateHealth() {
     refetchInterval: 15000,
   });
 }
+
+export function useGraphSvg(params: {
+  phases: string[];
+  chapters: string[];
+  q: string;
+  enabled?: boolean;
+}) {
+  const qs = new URLSearchParams();
+  if (params.phases.length) qs.set('phases', params.phases.join(','));
+  if (params.chapters.length) qs.set('chapters', params.chapters.join(','));
+  if (params.q) qs.set('q', params.q);
+  const url = '/api/graph/svg?' + qs.toString();
+  return useQuery<string>({
+    queryKey: ['graph-svg', params.phases.join(','), params.chapters.join(','), params.q],
+    queryFn: async () => {
+      const res = await fetch(apiUrl(url));
+      if (!res.ok) throw new Error(`API ${res.status}`);
+      return res.text();
+    },
+    enabled: params.enabled !== false,
+    staleTime: 5000,
+    placeholderData: (prev) => prev,  // keep old SVG visible while re-fetching
+  });
+}

--- a/ui/client/src/hooks/useApi.ts
+++ b/ui/client/src/hooks/useApi.ts
@@ -1,6 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
 import { apiUrl } from '../utils/constants';
-import type { LogEntry, AggregatedStats, LogsResponse, AgentSummary } from '../types';
+import type {
+  LogEntry, AggregatedStats, LogsResponse, AgentSummary,
+  GraphPayload, NodeDetail, StateHealth,
+} from '../types';
 
 async function fetchJson<T>(url: string): Promise<T> {
   const res = await fetch(apiUrl(url));
@@ -38,5 +41,29 @@ export function useLogContent(filename: string) {
     queryFn: () => fetchJson(`/api/logs/${filename}`),
     enabled: !!filename,
     refetchInterval: false,
+  });
+}
+
+export function useGraph() {
+  return useQuery<GraphPayload>({
+    queryKey: ['graph'],
+    queryFn: () => fetchJson('/api/graph'),
+    refetchInterval: 15000,
+  });
+}
+
+export function useNode(id: string) {
+  return useQuery<NodeDetail>({
+    queryKey: ['node', id],
+    queryFn: () => fetchJson(`/api/nodes/${encodeURIComponent(id)}`),
+    enabled: !!id,
+  });
+}
+
+export function useStateHealth() {
+  return useQuery<StateHealth>({
+    queryKey: ['stateHealth'],
+    queryFn: () => fetchJson('/api/state/health'),
+    refetchInterval: 15000,
   });
 }

--- a/ui/client/src/types/cytoscape-dagre.d.ts
+++ b/ui/client/src/types/cytoscape-dagre.d.ts
@@ -1,0 +1,4 @@
+declare module 'cytoscape-dagre' {
+  const ext: cytoscape.Ext;
+  export default ext;
+}

--- a/ui/client/src/types/cytoscape-dagre.d.ts
+++ b/ui/client/src/types/cytoscape-dagre.d.ts
@@ -1,4 +1,0 @@
-declare module 'cytoscape-dagre' {
-  const ext: cytoscape.Ext;
-  export default ext;
-}

--- a/ui/client/src/types/index.ts
+++ b/ui/client/src/types/index.ts
@@ -78,6 +78,7 @@ export interface NodeData {
   id: string;
   kind: string | null;
   chapter: string | null;
+  subsection: string | null;
   sourceFile: string | null;
   sourceLine: number | null;
   leanDecl: string | null;

--- a/ui/client/src/types/index.ts
+++ b/ui/client/src/types/index.ts
@@ -95,12 +95,13 @@ export interface EdgeData {
   from: string;
   to: string;
   source: string;
-  confirmed: boolean;
 }
 
 export interface GraphPayload {
   nodes: NodeData[];
   edges: EdgeData[];
+  /** Chapters in the order they're \input'd from content.tex (with ≥1 node). */
+  chapters: string[];
 }
 
 export interface NodeComment {
@@ -142,8 +143,8 @@ export interface RenderedNode {
 
 export interface NodeDetail extends Omit<NodeData, 'leanDecl'> {
   comments: NodeComment[];
-  uses: { id: string; confirmed: boolean }[];
-  usedBy: { id: string; confirmed: boolean }[];
+  uses: { id: string }[];
+  usedBy: { id: string }[];
   leanDecl: LeanDeclInfo | null;
   runs: NodeRunInfo[];
   nlExcerpt: string | null;

--- a/ui/client/src/types/index.ts
+++ b/ui/client/src/types/index.ts
@@ -147,6 +147,7 @@ export interface NodeDetail extends Omit<NodeData, 'leanDecl'> {
   uses: { id: string }[];
   usedBy: { id: string }[];
   leanDecl: LeanDeclInfo | null;
+  leanSource: string | null;
   runs: NodeRunInfo[];
   nlExcerpt: string | null;
   nlRendered: RenderedNode | null;

--- a/ui/client/src/types/index.ts
+++ b/ui/client/src/types/index.ts
@@ -62,3 +62,98 @@ export interface AggregatedStats {
   sessionCount: number;
   sessions: SessionSummary[];
 }
+
+// ===== KIP node-state types =====================================================
+
+export type Phase = 'drafted' | 'nl_reviewed' | 'bound' | 'aligned' | 'proved';
+
+export interface NodeFlags {
+  nlReviewed: boolean;
+  bound: boolean;
+  aligned: boolean;
+  proved: boolean;
+}
+
+export interface NodeData {
+  id: string;
+  kind: string | null;
+  chapter: string | null;
+  sourceFile: string | null;
+  sourceLine: number | null;
+  leanDecl: string | null;
+  leanok: boolean;
+  nlHash: string | null;
+  flags: NodeFlags;
+  nlReviewer: string | null;
+  alignReviewer: string | null;
+  alignedAt: string | null;
+  lastActivity: string | null;
+  phase: Phase;
+}
+
+export interface EdgeData {
+  from: string;
+  to: string;
+  source: string;
+  confirmed: boolean;
+}
+
+export interface GraphPayload {
+  nodes: NodeData[];
+  edges: EdgeData[];
+}
+
+export interface NodeComment {
+  idx: number;
+  topic: string | null;
+  text: string | null;
+  by: string | null;
+  at: string | null;
+}
+
+export interface LeanDeclInfo {
+  name: string;
+  file: string;
+  line_start: number;
+  line_end: number;
+  sorry_count: number;
+}
+
+export interface NodeRunInfo {
+  id: string;
+  agent: string;
+  started_at: string | null;
+  completed_at: string | null;
+  status: string | null;
+  model: string | null;
+  hint_file: string | null;
+  cost_usd: number | null;
+  duration_ms: number | null;
+  num_turns: number | null;
+  summary: string | null;
+  log_path: string | null;
+}
+
+export interface RenderedNode {
+  caption: string;
+  label: string;
+  contentHtml: string;
+}
+
+export interface NodeDetail extends Omit<NodeData, 'leanDecl'> {
+  comments: NodeComment[];
+  uses: { id: string; confirmed: boolean }[];
+  usedBy: { id: string; confirmed: boolean }[];
+  leanDecl: LeanDeclInfo | null;
+  runs: NodeRunInfo[];
+  nlExcerpt: string | null;
+  nlRendered: RenderedNode | null;
+}
+
+export interface StateHealth {
+  ok: boolean;
+  error?: string;
+  meta?: { indexed_at?: string; schema_version?: string };
+  counts?: { nodes: number; edges: number; lean_decls: number; agent_runs: number };
+  phases?: Partial<Record<Phase, number>>;
+}

--- a/ui/client/src/utils/constants.ts
+++ b/ui/client/src/utils/constants.ts
@@ -31,3 +31,39 @@ export const STATUS_COLORS: Record<string, string> = {
   error: 'var(--red)',
   pending: 'var(--orange)',
 };
+
+// Phase = node lifecycle stage (drafted → proved). Ordered cool→warm→green.
+// nl_reviewed implicitly includes "dependency edges confirmed" — they're not
+// tracked separately in status.yaml.
+export const PHASE_COLORS: Record<string, string> = {
+  drafted:     '#c9ccd1',  // gray — only NL skeleton
+  nl_reviewed: '#6f42c1',  // purple — NL + deps signed off
+  bound:       '#0366d6',  // blue — Lean decl exists (sorry-stub OK)
+  aligned:     '#e36209',  // orange — humans confirm Lean ↔ NL match
+  proved:      '#28a745',  // green — sorry filled, build green
+};
+
+export const PHASE_ORDER = ['drafted', 'nl_reviewed', 'bound', 'aligned', 'proved'] as const;
+
+export const PHASE_LABELS: Record<string, string> = {
+  drafted: 'Drafted',
+  nl_reviewed: 'NL reviewed',
+  bound: 'Bound',
+  aligned: 'Aligned',
+  proved: 'Proved',
+};
+
+// Cytoscape node shapes per LaTeX kind. Splits things into 3 visual buckets:
+// data (definition/notation) · claim (theorem/prop/lemma/corollary) · meta (axiom/remark/...)
+export const KIND_SHAPES: Record<string, string> = {
+  definition:  'ellipse',
+  notation:    'ellipse',
+  theorem:     'round-rectangle',
+  proposition: 'round-rectangle',
+  lemma:       'round-rectangle',
+  corollary:   'round-rectangle',
+  axiom:       'rectangle',
+  remark:      'hexagon',
+  question:    'vee',
+  example:     'triangle',
+};

--- a/ui/client/src/utils/leanHighlight.ts
+++ b/ui/client/src/utils/leanHighlight.ts
@@ -1,0 +1,88 @@
+// Tiny Lean-4 highlighter — enough for the dashboard's read-only "Lean
+// declaration" preview, not enough to be a real grammar. Comments, strings,
+// attributes, numbers, and a curated keyword/tactic list get span-wrapped;
+// everything else passes through as plain text.
+//
+// Known approximations (matching the indexer's regex heuristics):
+//   * block comments aren't nested — `/-` and `-/` are treated as a flat pair
+//   * unicode identifiers fall through unhighlighted (keyword set is ASCII)
+//   * tactic-mode is not distinguished from term-mode; we just colour any
+//     occurrence of a known tactic name. False positives in identifier-like
+//     positions are tolerated for readability.
+
+const KEYWORDS = new Set<string>([
+  // top-level / structuring
+  'import', 'open', 'export', 'namespace', 'section', 'end',
+  'variable', 'variables', 'universe', 'universes',
+  'mutual', 'private', 'protected', 'noncomputable', 'partial', 'unsafe',
+  'attribute', 'local', 'scoped', 'syntax', 'macro', 'macro_rules',
+  'elab', 'elab_rules',
+  // declarations
+  'theorem', 'lemma', 'def', 'abbrev', 'axiom',
+  'structure', 'class', 'instance', 'inductive', 'coinductive',
+  'example', 'opaque',
+  // term-level
+  'where', 'with', 'match', 'fun', 'if', 'then', 'else',
+  'do', 'let', 'in', 'from', 'return',
+  'have', 'show', 'suffices',
+  // tactics that appear often in our codebase
+  'by', 'sorry', 'admit', 'rfl',
+  'refine', 'exact', 'apply', 'intro', 'intros',
+  'cases', 'induction', 'rcases', 'rintro', 'obtain', 'use',
+  'simp', 'rw', 'rewrite', 'calc', 'decide', 'omega', 'linarith',
+  'aesop', 'ring', 'field_simp', 'norm_num', 'gcongr', 'positivity',
+  'constructor', 'left', 'right', 'split', 'contradiction',
+  'first', 'all_goals', 'any_goals', 'try', 'repeat',
+  // sorts and well-known constants
+  'Type', 'Sort', 'Prop', 'True', 'False',
+]);
+
+function escHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+// One regex, ordered by priority. Comments and strings come first so a
+// keyword-looking word inside them isn't separately matched.
+const TOKEN_RE = new RegExp(
+  [
+    /(\/-[\s\S]*?-\/)/.source,                 // 1: block comment
+    /(--[^\n]*)/.source,                       // 2: line comment
+    /("(?:[^"\\]|\\.)*")/.source,              // 3: string literal
+    /(@\[[^\]]*\])/.source,                    // 4: attribute  e.g. @[simp]
+    /(\b[A-Za-z_][A-Za-z_0-9']*\b)/.source,    // 5: ascii ident / keyword
+    /(\b\d+(?:\.\d+)?\b)/.source,              // 6: number literal
+  ].join('|'),
+  'g',
+);
+
+export function highlightLean(src: string): string {
+  let out = '';
+  let last = 0;
+  let m: RegExpExecArray | null;
+  TOKEN_RE.lastIndex = 0;
+  while ((m = TOKEN_RE.exec(src)) !== null) {
+    if (m.index > last) out += escHtml(src.slice(last, m.index));
+    if (m[1] !== undefined || m[2] !== undefined) {
+      out += `<span class="lean-c">${escHtml(m[0])}</span>`;
+    } else if (m[3] !== undefined) {
+      out += `<span class="lean-s">${escHtml(m[0])}</span>`;
+    } else if (m[4] !== undefined) {
+      out += `<span class="lean-a">${escHtml(m[0])}</span>`;
+    } else if (m[5] !== undefined) {
+      const w = m[5];
+      out += KEYWORDS.has(w)
+        ? `<span class="lean-k">${escHtml(w)}</span>`
+        : escHtml(w);
+    } else if (m[6] !== undefined) {
+      out += `<span class="lean-n">${escHtml(m[0])}</span>`;
+    } else {
+      out += escHtml(m[0]);
+    }
+    last = m.index + m[0].length;
+  }
+  if (last < src.length) out += escHtml(src.slice(last));
+  return out;
+}

--- a/ui/client/src/utils/mathjax.ts
+++ b/ui/client/src/utils/mathjax.ts
@@ -26,7 +26,8 @@ export function ensureMathJax(): Promise<void> {
       startup: { typeset: false },
     };
     const s = document.createElement('script');
-    s.src = 'https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js';
+    // Pin to a specific patch (the bare `mathjax@3` tag rolls forward).
+    s.src = 'https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/tex-chtml.js';
     s.async = true;
     s.onload = () => {
       const mj = window.MathJax as MathJaxV3 | undefined;

--- a/ui/client/src/utils/mathjax.ts
+++ b/ui/client/src/utils/mathjax.ts
@@ -1,0 +1,50 @@
+// Lazy MathJax v3 loader. Mirrors the config blueprint's web pages use so
+// rendered LaTeX blocks coming from blueprint/web/sec-*.html typeset identically.
+
+interface MathJaxV3 {
+  startup?: { promise?: Promise<void> };
+  typesetPromise?: (elements?: HTMLElement[]) => Promise<void>;
+  typesetClear?: (elements?: HTMLElement[]) => void;
+}
+
+declare global {
+  interface Window {
+    MathJax?: MathJaxV3 | Record<string, unknown>;
+  }
+}
+
+let loadPromise: Promise<void> | null = null;
+
+export function ensureMathJax(): Promise<void> {
+  if (loadPromise) return loadPromise;
+  if (typeof window === 'undefined') return Promise.resolve();
+
+  loadPromise = new Promise<void>((resolve) => {
+    // Configure BEFORE the script loads (this is how MathJax v3 picks up config).
+    (window as Window).MathJax = {
+      tex: { inlineMath: [['$', '$'], ['\\(', '\\)']] },
+      startup: { typeset: false },
+    };
+    const s = document.createElement('script');
+    s.src = 'https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js';
+    s.async = true;
+    s.onload = () => {
+      const mj = window.MathJax as MathJaxV3 | undefined;
+      const startup = mj?.startup?.promise;
+      if (startup) startup.then(() => resolve()).catch(() => resolve());
+      else resolve();
+    };
+    s.onerror = () => resolve();  // give up silently; raw HTML still shows
+    document.head.appendChild(s);
+  });
+  return loadPromise;
+}
+
+export async function typesetMath(el: HTMLElement | null): Promise<void> {
+  if (!el) return;
+  await ensureMathJax();
+  const mj = window.MathJax as MathJaxV3 | undefined;
+  if (mj?.typesetPromise) {
+    try { await mj.typesetPromise([el]); } catch { /* ignore typeset errors */ }
+  }
+}

--- a/ui/client/src/views/Nodes.module.css
+++ b/ui/client/src/views/Nodes.module.css
@@ -1,0 +1,115 @@
+.root {
+  display: grid;
+  grid-template-columns: 220px 1fr 0fr;
+  height: 100%;
+  min-height: 0;
+  transition: grid-template-columns 220ms ease;
+}
+.root.drawerOpen { grid-template-columns: 220px 1fr 420px; }
+
+.sidebar {
+  border-right: 1px solid var(--border);
+  background: var(--bg-secondary);
+  padding: 12px;
+  overflow-y: auto;
+  font-size: 12px;
+}
+.sidebarTitle {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+  font-size: 10px;
+  margin: 12px 0 6px;
+}
+.sidebarTitle:first-child { margin-top: 0; }
+
+.search {
+  width: 100%;
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 12px;
+  font-family: var(--font-mono);
+  background: var(--bg-primary);
+}
+.search:focus { outline: none; border-color: var(--blue); }
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--bg-primary);
+  cursor: pointer;
+  font-size: 11px;
+  user-select: none;
+}
+.chip:hover { border-color: var(--text-muted); }
+.chipActive { background: var(--bg-tertiary); border-color: var(--text-secondary); color: var(--text-primary); }
+.chipDot {
+  width: 8px; height: 8px; border-radius: 50%;
+  display: inline-block;
+}
+.chipCount { color: var(--text-muted); font-variant-numeric: tabular-nums; }
+
+.legend { font-size: 11px; color: var(--text-secondary); }
+.legendRow { display: flex; align-items: center; gap: 6px; margin: 3px 0; }
+.legendSwatch { width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; }
+.legendShape { width: 14px; height: 14px; border: 1.5px solid var(--text-secondary); flex-shrink: 0; }
+.legendShape.ellipse { border-radius: 50%; }
+.legendShape.round { border-radius: 4px; }
+.legendShape.rect { border-radius: 0; }
+.legendShape.hex { transform: rotate(90deg); clip-path: polygon(25% 0, 75% 0, 100% 50%, 75% 100%, 25% 100%, 0 50%); border: none; background: transparent; box-shadow: 0 0 0 1.5px var(--text-secondary) inset; }
+
+.canvas {
+  position: relative;
+  background: var(--bg-primary);
+  min-height: 0;
+  min-width: 0;
+}
+.canvasInner { position: absolute; inset: 0; }
+.canvasOverlay {
+  position: absolute;
+  bottom: 12px;
+  left: 12px;
+  background: rgba(255,255,255,0.92);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 6px 10px;
+  font-size: 11px;
+  color: var(--text-secondary);
+  pointer-events: none;
+  font-variant-numeric: tabular-nums;
+}
+.canvasMissing {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--text-muted);
+  font-size: 13px;
+  text-align: center;
+  padding: 24px;
+}
+.canvasMissing code {
+  background: var(--bg-tertiary);
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 11px;
+}
+
+.drawer {
+  border-left: 1px solid var(--border);
+  background: var(--bg-primary);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}

--- a/ui/client/src/views/Nodes.module.css
+++ b/ui/client/src/views/Nodes.module.css
@@ -1,11 +1,12 @@
 .root {
   display: grid;
-  grid-template-columns: 220px 1fr 0fr;
+  grid-template-columns: 220px 1fr;
   height: 100%;
   min-height: 0;
-  transition: grid-template-columns 220ms ease;
+  position: relative;  /* anchor for the floating drawer */
 }
-.root.drawerOpen { grid-template-columns: 220px 1fr 420px; }
+/* Kept for the App.tsx className concat — no longer changes layout. */
+.drawerOpen {}
 
 .sidebar {
   border-right: 1px solid var(--border);
@@ -126,10 +127,20 @@
   font-size: 11px;
 }
 
+/* Drawer is overlaid on the canvas (absolute position) instead of pushing
+   it. This keeps the SVG geometry stable across selection toggles, so
+   svg-pan-zoom's current pan/zoom isn't visually reset every click. */
 .drawer {
-  border-left: 1px solid var(--border);
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 420px;
   background: var(--bg-primary);
+  border-left: 1px solid var(--border);
+  box-shadow: -4px 0 12px rgba(0, 0, 0, 0.05);
   overflow-y: auto;
+  z-index: 10;
   display: flex;
   flex-direction: column;
 }

--- a/ui/client/src/views/Nodes.module.css
+++ b/ui/client/src/views/Nodes.module.css
@@ -97,6 +97,26 @@
   stroke-width: 3px;
 }
 .canvasInner :global(g.kip-node-selected) text { font-weight: 600; }
+
+/* Edge highlight on node selection. Graphviz emits each edge as a <g> with
+   one <path> (the curve) and one <polygon> (the arrowhead). The default
+   stroke on the <polygon> is "none" with a fill, so we set both. */
+.canvasInner :global(g.kip-edge-uses) > path {
+  stroke: #0366d6;
+  stroke-width: 2.2px;
+}
+.canvasInner :global(g.kip-edge-uses) > polygon {
+  stroke: #0366d6;
+  fill: #0366d6;
+}
+.canvasInner :global(g.kip-edge-usedby) > path {
+  stroke: #e36209;
+  stroke-width: 2.2px;
+}
+.canvasInner :global(g.kip-edge-usedby) > polygon {
+  stroke: #e36209;
+  fill: #e36209;
+}
 .canvasOverlay {
   position: absolute;
   bottom: 12px;
@@ -135,7 +155,7 @@
   top: 0;
   right: 0;
   bottom: 0;
-  width: 420px;
+  width: 420px;  /* default; React inline style overrides w/ persisted px */
   background: var(--bg-primary);
   border-left: 1px solid var(--border);
   box-shadow: -4px 0 12px rgba(0, 0, 0, 0.05);
@@ -143,4 +163,22 @@
   z-index: 10;
   display: flex;
   flex-direction: column;
+}
+
+/* Thin invisible drag-strip just to the left of the drawer. Slightly wider
+   than the visible border so it's easy to grab; tints on hover/active so the
+   user gets feedback. */
+.drawerResize {
+  position: absolute;
+  top: 0;
+  left: -3px;
+  bottom: 0;
+  width: 6px;
+  cursor: col-resize;
+  z-index: 11;
+  background: transparent;
+}
+.drawerResize:hover,
+.drawerResize:active {
+  background: rgba(3, 102, 214, 0.25);
 }

--- a/ui/client/src/views/Nodes.module.css
+++ b/ui/client/src/views/Nodes.module.css
@@ -76,6 +76,26 @@
   min-width: 0;
 }
 .canvasInner { position: absolute; inset: 0; }
+
+/* Server-rendered Graphviz SVG. dot uses different shape elements per node
+   kind (ellipse / polygon / path / rect), so the highlight selectors cast a
+   wide net. */
+.canvasInner :global(g.kip-node) { cursor: pointer; }
+.canvasInner :global(g.kip-node:hover) ellipse,
+.canvasInner :global(g.kip-node:hover) polygon,
+.canvasInner :global(g.kip-node:hover) path,
+.canvasInner :global(g.kip-node:hover) rect {
+  stroke: #0366d6;
+  stroke-width: 2px;
+}
+.canvasInner :global(g.kip-node-selected) ellipse,
+.canvasInner :global(g.kip-node-selected) polygon,
+.canvasInner :global(g.kip-node-selected) path,
+.canvasInner :global(g.kip-node-selected) rect {
+  stroke: #0366d6;
+  stroke-width: 3px;
+}
+.canvasInner :global(g.kip-node-selected) text { font-weight: 600; }
 .canvasOverlay {
   position: absolute;
   bottom: 12px;

--- a/ui/client/src/views/Nodes.tsx
+++ b/ui/client/src/views/Nodes.tsx
@@ -14,6 +14,13 @@ export default function Nodes() {
   const navigate = useNavigate();
   const containerRef = useRef<HTMLDivElement | null>(null);
   const panZoomRef = useRef<SvgPanZoom.Instance | null>(null);
+  // navigate's reference may not be perfectly stable across renders (or
+  // an upstream provider re-render); keep it behind a ref so the SVG mount
+  // effect doesn't fire just because navigate's identity changed —
+  // re-initialising svg-pan-zoom with `fit:true,center:true` would reset
+  // the user's current zoom/pan on every click.
+  const navRef = useRef(navigate);
+  useEffect(() => { navRef.current = navigate; }, [navigate]);
 
   const [selectedId, setSelectedId] = useState('');
   const [search, setSearch] = useState('');
@@ -99,33 +106,48 @@ export default function Nodes() {
         if (id && id.startsWith('node:')) {
           const nodeId = id.slice('node:'.length);
           setSelectedId(nodeId);
-          navigate(`/nodes/${encodeURIComponent(nodeId)}`);
+          navRef.current(`/nodes/${encodeURIComponent(nodeId)}`);
           return;
         }
         target = target.parentElement;
       }
       // Background click → deselect
       setSelectedId('');
-      navigate('/nodes');
+      navRef.current('/nodes');
     };
     svgEl.addEventListener('click', onClick);
 
-    // Init pan-zoom
+    // Init pan-zoom. If a previous instance exists (filter change → new
+    // SVG), preserve its pan/zoom across the re-init so users don't lose
+    // context. fit/center only fire on the very first mount.
+    let preservedZoom: number | null = null;
+    let preservedPan: { x: number; y: number } | null = null;
     if (panZoomRef.current) {
+      try {
+        preservedZoom = panZoomRef.current.getZoom();
+        preservedPan = panZoomRef.current.getPan();
+      } catch { /* ignore */ }
       try { panZoomRef.current.destroy(); } catch { /* ignore */ }
       panZoomRef.current = null;
     }
+    const isFirstMount = preservedZoom == null;
     panZoomRef.current = svgPanZoom(svgEl, {
       zoomEnabled: true,
       controlIconsEnabled: false,
-      fit: true,
-      center: true,
+      fit: isFirstMount,
+      center: isFirstMount,
       mouseWheelZoomEnabled: true,
       preventMouseEventsDefault: false,
       minZoom: 0.2,
       maxZoom: 8,
       zoomScaleSensitivity: 0.4,
     });
+    if (!isFirstMount && preservedZoom != null && preservedPan) {
+      try {
+        panZoomRef.current.zoom(preservedZoom);
+        panZoomRef.current.pan(preservedPan);
+      } catch { /* ignore */ }
+    }
 
     return () => {
       svgEl.removeEventListener('click', onClick);
@@ -134,7 +156,8 @@ export default function Nodes() {
         panZoomRef.current = null;
       }
     };
-  }, [svgText, navigate]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [svgText]);
 
   // Highlight selected node in SVG
   useEffect(() => {

--- a/ui/client/src/views/Nodes.tsx
+++ b/ui/client/src/views/Nodes.tsx
@@ -40,9 +40,7 @@ export default function Nodes() {
   // Initialize chapter filter to "all chapters" once we know what they are.
   useEffect(() => {
     if (chaptersInit || !graph) return;
-    const all = new Set<string>();
-    for (const n of graph.nodes) if (n.chapter) all.add(n.chapter);
-    setActiveChapters(all);
+    setActiveChapters(new Set(graph.chapters));
     setChaptersInit(true);
   }, [graph, chaptersInit]);
 
@@ -52,12 +50,9 @@ export default function Nodes() {
     if (next !== selectedId) setSelectedId(next);
   }, [routeId, selectedId]);
 
-  const allChapters = useMemo(() => {
-    if (!graph) return [] as string[];
-    const set = new Set<string>();
-    for (const n of graph.nodes) if (n.chapter) set.add(n.chapter);
-    return Array.from(set).sort();
-  }, [graph]);
+  // Chapter chips render in content.tex order (server returns them already
+  // sorted). Don't re-sort here.
+  const allChapters = graph?.chapters ?? [];
 
   const phaseCounts = useMemo(() => {
     const counts: Record<string, number> = {};
@@ -72,9 +67,11 @@ export default function Nodes() {
   }, [graph]);
 
   const phasesArr = useMemo(() => Array.from(activePhases), [activePhases]);
+  // Preserve content.tex order in the query string so the cache key for
+  // /api/graph/svg matches across renders regardless of toggle order.
   const chaptersArr = useMemo(
-    () => (chaptersInit ? Array.from(activeChapters).sort() : []),
-    [activeChapters, chaptersInit],
+    () => (chaptersInit ? allChapters.filter(c => activeChapters.has(c)) : []),
+    [allChapters, activeChapters, chaptersInit],
   );
 
   const { data: svgText, isFetching, isError } = useGraphSvg({
@@ -242,8 +239,8 @@ export default function Nodes() {
 
         <div className={styles.sidebarTitle}>Edges</div>
         <div className={styles.legend}>
-          <div className={styles.legendRow}>solid → confirmed dependency</div>
-          <div className={styles.legendRow}>dashed → unconfirmed (default)</div>
+          <div className={styles.legendRow}>top → bottom = build order</div>
+          <div className={styles.legendRow}>arrow A → B reads "A is used by B"</div>
         </div>
       </aside>
 

--- a/ui/client/src/views/Nodes.tsx
+++ b/ui/client/src/views/Nodes.tsx
@@ -129,9 +129,11 @@ export default function Nodes() {
     setChaptersInitialized(true);
   }, [graph, chaptersInitialized]);
 
-  // route → state sync
+  // route → state sync (also clears selection when URL drops the :id segment,
+  // e.g. browser Back from /nodes/:id to /nodes)
   useEffect(() => {
-    if (routeId && routeId !== selectedId) setSelectedId(routeId);
+    const next = routeId || '';
+    if (next !== selectedId) setSelectedId(next);
   }, [routeId, selectedId]);
 
   const allChapters = useMemo(() => {

--- a/ui/client/src/views/Nodes.tsx
+++ b/ui/client/src/views/Nodes.tsx
@@ -1,0 +1,346 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import cytoscape from 'cytoscape';
+import dagre from 'cytoscape-dagre';
+import { useGraph } from '../hooks/useApi';
+import { PHASE_COLORS, PHASE_ORDER, PHASE_LABELS, KIND_SHAPES } from '../utils/constants';
+import NodeDetail from '../components/NodeDetail';
+import type { GraphPayload, NodeData, Phase } from '../types';
+import styles from './Nodes.module.css';
+
+cytoscape.use(dagre);
+
+const ALL_PHASES = [...PHASE_ORDER];
+
+function lastSegment(id: string): string {
+  const parts = id.split(':');
+  return parts[parts.length - 1] || id;
+}
+
+function buildElements(graph: GraphPayload, visibleIds: Set<string>) {
+  const els: cytoscape.ElementDefinition[] = [];
+  for (const n of graph.nodes) {
+    if (!visibleIds.has(n.id)) continue;
+    els.push({
+      data: {
+        id: n.id,
+        label: lastSegment(n.id),
+        color: PHASE_COLORS[n.phase] || '#999',
+        shape: KIND_SHAPES[n.kind || ''] || 'ellipse',
+        kind: n.kind,
+        phase: n.phase,
+      },
+    });
+  }
+  for (const e of graph.edges) {
+    if (!visibleIds.has(e.from) || !visibleIds.has(e.to)) continue;
+    els.push({
+      data: {
+        id: `${e.from}__${e.to}`,
+        source: e.from,
+        target: e.to,
+        confirmed: e.confirmed ? 1 : 0,
+      },
+    });
+  }
+  return els;
+}
+
+const CY_STYLE: cytoscape.StylesheetCSS[] = [
+  {
+    selector: 'node',
+    css: {
+      'background-color': 'data(color)' as unknown as string,
+      'shape': 'data(shape)' as cytoscape.Css.NodeShape,
+      'label': 'data(label)',
+      'font-size': 9,
+      'font-family': "'SF Mono', 'Menlo', monospace",
+      'text-valign': 'center',
+      'text-halign': 'center',
+      'color': '#1a1a1a',
+      'text-outline-color': '#fff',
+      'text-outline-width': 2,
+      'width': 60,
+      'height': 28,
+      'border-width': 1,
+      'border-color': 'rgba(0,0,0,0.18)',
+      'text-wrap': 'ellipsis' as 'wrap',
+      'text-max-width': '70px',
+    },
+  },
+  {
+    selector: 'node:selected',
+    css: {
+      'border-width': 3,
+      'border-color': '#0366d6',
+      'border-style': 'solid',
+    },
+  },
+  {
+    selector: 'edge',
+    css: {
+      'width': 1,
+      'line-color': '#c9ccd1',
+      'target-arrow-color': '#c9ccd1',
+      'target-arrow-shape': 'triangle',
+      'arrow-scale': 0.8,
+      'curve-style': 'bezier',
+      'opacity': 0.7,
+    },
+  },
+  {
+    selector: 'edge[confirmed = 0]',
+    css: {
+      'line-style': 'dashed',
+    },
+  },
+  {
+    selector: '.faded',
+    css: { 'opacity': 0.18 },
+  },
+  {
+    selector: '.highlighted',
+    css: { 'opacity': 1, 'z-index': 100 },
+  },
+  {
+    selector: 'edge.highlighted',
+    css: { 'line-color': '#0366d6', 'target-arrow-color': '#0366d6', 'width': 2 },
+  },
+];
+
+export default function Nodes() {
+  const { data: graph } = useGraph();
+  const { id: routeId } = useParams<{ id?: string }>();
+  const navigate = useNavigate();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const cyRef = useRef<cytoscape.Core | null>(null);
+  const [selectedId, setSelectedId] = useState<string>('');
+  const [search, setSearch] = useState('');
+  const [activePhases, setActivePhases] = useState<Set<Phase>>(() => new Set<Phase>(ALL_PHASES));
+  const [activeChapters, setActiveChapters] = useState<Set<string>>(() => new Set());
+  const [chaptersInitialized, setChaptersInitialized] = useState(false);
+
+  // initialize active chapters once we know what they are
+  useEffect(() => {
+    if (chaptersInitialized || !graph) return;
+    const all = new Set<string>();
+    for (const n of graph.nodes) if (n.chapter) all.add(n.chapter);
+    setActiveChapters(all);
+    setChaptersInitialized(true);
+  }, [graph, chaptersInitialized]);
+
+  // route → state sync
+  useEffect(() => {
+    if (routeId && routeId !== selectedId) setSelectedId(routeId);
+  }, [routeId, selectedId]);
+
+  const allChapters = useMemo(() => {
+    if (!graph) return [] as string[];
+    const set = new Set<string>();
+    for (const n of graph.nodes) if (n.chapter) set.add(n.chapter);
+    return Array.from(set).sort();
+  }, [graph]);
+
+  // counts per phase / chapter
+  const phaseCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    if (graph) for (const n of graph.nodes) counts[n.phase] = (counts[n.phase] || 0) + 1;
+    return counts;
+  }, [graph]);
+
+  const chapterCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    if (graph) for (const n of graph.nodes) if (n.chapter) counts[n.chapter] = (counts[n.chapter] || 0) + 1;
+    return counts;
+  }, [graph]);
+
+  // visible node set after filters
+  const visibleIds = useMemo(() => {
+    const set = new Set<string>();
+    if (!graph) return set;
+    const q = search.trim().toLowerCase();
+    for (const n of graph.nodes) {
+      if (!activePhases.has(n.phase)) continue;
+      // chapter filter only applies to nodes with a chapter; orphans (no source) always shown
+      if (n.chapter && !activeChapters.has(n.chapter)) continue;
+      if (q) {
+        const hay = `${n.id} ${n.leanDecl || ''}`.toLowerCase();
+        if (!hay.includes(q)) continue;
+      }
+      // skip orphans (no source) when not searched explicitly
+      if (!n.chapter && !q) continue;
+      set.add(n.id);
+    }
+    return set;
+  }, [graph, activePhases, activeChapters, search]);
+
+  // (re)mount cytoscape when graph or filter changes
+  useEffect(() => {
+    if (!graph || !containerRef.current) return;
+    if (cyRef.current) {
+      cyRef.current.destroy();
+      cyRef.current = null;
+    }
+    const elements = buildElements(graph, visibleIds);
+    const cy = cytoscape({
+      container: containerRef.current,
+      elements,
+      style: CY_STYLE,
+      layout: {
+        name: 'dagre',
+        rankDir: 'TB',
+        nodeSep: 14,
+        rankSep: 40,
+        edgeSep: 8,
+      } as unknown as cytoscape.LayoutOptions,
+      wheelSensitivity: 1,
+      minZoom: 0.1,
+      maxZoom: 4,
+    });
+    // Edges are visual structure only, not interactive targets.
+    cy.edges().unselectify();
+    cy.on('tap', 'node', (evt) => {
+      const id = evt.target.id() as string;
+      setSelectedId(id);
+      navigate(`/nodes/${encodeURIComponent(id)}`);
+    });
+    cy.on('tap', (evt) => {
+      // treat background AND edge taps as "deselect" so an edge click
+      // doesn't leave a stale selection ring or open a drawer.
+      if (evt.target === cy || (evt.target.isEdge && evt.target.isEdge())) {
+        setSelectedId('');
+        navigate('/nodes');
+      }
+    });
+    cyRef.current = cy;
+    return () => { cy.destroy(); cyRef.current = null; };
+  }, [graph, visibleIds, navigate]);
+
+  // highlight selected + neighborhood
+  useEffect(() => {
+    const cy = cyRef.current;
+    if (!cy) return;
+    cy.elements().removeClass('highlighted faded');
+    if (!selectedId) return;
+    const sel = cy.getElementById(selectedId);
+    if (sel.empty()) return;
+    const neighborhood = sel.closedNeighborhood();
+    cy.elements().difference(neighborhood).addClass('faded');
+    neighborhood.addClass('highlighted');
+    sel.select();
+    // gently bring it into view if it's far off-screen
+    const bb = sel.boundingBox({});
+    const ext = cy.extent();
+    if (bb.x1 < ext.x1 || bb.x2 > ext.x2 || bb.y1 < ext.y1 || bb.y2 > ext.y2) {
+      cy.center(sel);
+    }
+  }, [selectedId, visibleIds]);
+
+  const togglePhase = (p: Phase) => {
+    setActivePhases(prev => {
+      const next = new Set(prev);
+      if (next.has(p)) next.delete(p); else next.add(p);
+      return next;
+    });
+  };
+  const toggleChapter = (c: string) => {
+    setActiveChapters(prev => {
+      const next = new Set(prev);
+      if (next.has(c)) next.delete(c); else next.add(c);
+      return next;
+    });
+  };
+
+  if (!graph) {
+    return (
+      <div className={styles.canvasMissing}>
+        Loading graph data…
+      </div>
+    );
+  }
+
+  if (graph.nodes.length === 0) {
+    return (
+      <div className={styles.canvasMissing}>
+        State index is empty.<br/>
+        Run <code>python tools/kip-state/index.py</code> from the project root.
+      </div>
+    );
+  }
+
+  return (
+    <div className={`${styles.root} ${selectedId ? styles.drawerOpen : ''}`}>
+      <aside className={styles.sidebar}>
+        <div className={styles.sidebarTitle}>Search</div>
+        <input
+          className={styles.search}
+          type="text"
+          placeholder="id or lean decl…"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+        />
+
+        <div className={styles.sidebarTitle}>Phase</div>
+        <div className={styles.chips}>
+          {ALL_PHASES.map(p => (
+            <span
+              key={p}
+              className={`${styles.chip} ${activePhases.has(p) ? styles.chipActive : ''}`}
+              onClick={() => togglePhase(p)}
+              title={PHASE_LABELS[p]}
+            >
+              <span className={styles.chipDot} style={{ background: PHASE_COLORS[p] }} />
+              {PHASE_LABELS[p]}
+              <span className={styles.chipCount}>{phaseCounts[p] || 0}</span>
+            </span>
+          ))}
+        </div>
+
+        <div className={styles.sidebarTitle}>Chapter</div>
+        <div className={styles.chips}>
+          {allChapters.map(c => (
+            <span
+              key={c}
+              className={`${styles.chip} ${activeChapters.has(c) ? styles.chipActive : ''}`}
+              onClick={() => toggleChapter(c)}
+            >
+              {c}
+              <span className={styles.chipCount}>{chapterCounts[c] || 0}</span>
+            </span>
+          ))}
+        </div>
+
+        <div className={styles.sidebarTitle}>Shapes</div>
+        <div className={styles.legend}>
+          <div className={styles.legendRow}><span className={`${styles.legendShape} ${styles.ellipse}`} />definition / notation</div>
+          <div className={styles.legendRow}><span className={`${styles.legendShape} ${styles.round}`} />theorem / prop / lemma / cor</div>
+          <div className={styles.legendRow}><span className={`${styles.legendShape} ${styles.rect}`} />axiom</div>
+          <div className={styles.legendRow}><span className={`${styles.legendShape} ${styles.hex}`} />remark / question / example</div>
+        </div>
+
+        <div className={styles.sidebarTitle}>Edges</div>
+        <div className={styles.legend}>
+          <div className={styles.legendRow}>solid → confirmed dependency</div>
+          <div className={styles.legendRow}>dashed → unconfirmed (default)</div>
+        </div>
+      </aside>
+
+      <div className={styles.canvas}>
+        <div className={styles.canvasInner} ref={containerRef} />
+        <div className={styles.canvasOverlay}>
+          showing {visibleIds.size} / {graph.nodes.length} nodes
+        </div>
+      </div>
+
+      {selectedId && (
+        <div className={styles.drawer}>
+          <NodeDetail
+            nodeId={selectedId}
+            onClose={() => { setSelectedId(''); navigate('/nodes'); }}
+            onSelectNode={(id) => { setSelectedId(id); navigate(`/nodes/${encodeURIComponent(id)}`); }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/client/src/views/Nodes.tsx
+++ b/ui/client/src/views/Nodes.tsx
@@ -1,136 +1,45 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import cytoscape from 'cytoscape';
-import dagre from 'cytoscape-dagre';
-import { useGraph } from '../hooks/useApi';
-import { PHASE_COLORS, PHASE_ORDER, PHASE_LABELS, KIND_SHAPES } from '../utils/constants';
+import svgPanZoom from 'svg-pan-zoom';
+import { useGraph, useGraphSvg } from '../hooks/useApi';
+import { PHASE_COLORS, PHASE_ORDER, PHASE_LABELS } from '../utils/constants';
 import NodeDetail from '../components/NodeDetail';
-import type { GraphPayload, NodeData, Phase } from '../types';
+import type { Phase } from '../types';
 import styles from './Nodes.module.css';
-
-cytoscape.use(dagre);
 
 const ALL_PHASES = [...PHASE_ORDER];
 
-function lastSegment(id: string): string {
-  const parts = id.split(':');
-  return parts[parts.length - 1] || id;
-}
-
-function buildElements(graph: GraphPayload, visibleIds: Set<string>) {
-  const els: cytoscape.ElementDefinition[] = [];
-  for (const n of graph.nodes) {
-    if (!visibleIds.has(n.id)) continue;
-    els.push({
-      data: {
-        id: n.id,
-        label: lastSegment(n.id),
-        color: PHASE_COLORS[n.phase] || '#999',
-        shape: KIND_SHAPES[n.kind || ''] || 'ellipse',
-        kind: n.kind,
-        phase: n.phase,
-      },
-    });
-  }
-  for (const e of graph.edges) {
-    if (!visibleIds.has(e.from) || !visibleIds.has(e.to)) continue;
-    els.push({
-      data: {
-        id: `${e.from}__${e.to}`,
-        source: e.from,
-        target: e.to,
-        confirmed: e.confirmed ? 1 : 0,
-      },
-    });
-  }
-  return els;
-}
-
-const CY_STYLE: cytoscape.StylesheetCSS[] = [
-  {
-    selector: 'node',
-    css: {
-      'background-color': 'data(color)' as unknown as string,
-      'shape': 'data(shape)' as cytoscape.Css.NodeShape,
-      'label': 'data(label)',
-      'font-size': 9,
-      'font-family': "'SF Mono', 'Menlo', monospace",
-      'text-valign': 'center',
-      'text-halign': 'center',
-      'color': '#1a1a1a',
-      'text-outline-color': '#fff',
-      'text-outline-width': 2,
-      'width': 60,
-      'height': 28,
-      'border-width': 1,
-      'border-color': 'rgba(0,0,0,0.18)',
-      'text-wrap': 'ellipsis' as 'wrap',
-      'text-max-width': '70px',
-    },
-  },
-  {
-    selector: 'node:selected',
-    css: {
-      'border-width': 3,
-      'border-color': '#0366d6',
-      'border-style': 'solid',
-    },
-  },
-  {
-    selector: 'edge',
-    css: {
-      'width': 1,
-      'line-color': '#c9ccd1',
-      'target-arrow-color': '#c9ccd1',
-      'target-arrow-shape': 'triangle',
-      'arrow-scale': 0.8,
-      'curve-style': 'bezier',
-      'opacity': 0.7,
-    },
-  },
-  {
-    selector: 'edge[confirmed = 0]',
-    css: {
-      'line-style': 'dashed',
-    },
-  },
-  {
-    selector: '.faded',
-    css: { 'opacity': 0.18 },
-  },
-  {
-    selector: '.highlighted',
-    css: { 'opacity': 1, 'z-index': 100 },
-  },
-  {
-    selector: 'edge.highlighted',
-    css: { 'line-color': '#0366d6', 'target-arrow-color': '#0366d6', 'width': 2 },
-  },
-];
-
 export default function Nodes() {
-  const { data: graph } = useGraph();
   const { id: routeId } = useParams<{ id?: string }>();
   const navigate = useNavigate();
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const cyRef = useRef<cytoscape.Core | null>(null);
-  const [selectedId, setSelectedId] = useState<string>('');
+  const panZoomRef = useRef<SvgPanZoom.Instance | null>(null);
+
+  const [selectedId, setSelectedId] = useState('');
   const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
   const [activePhases, setActivePhases] = useState<Set<Phase>>(() => new Set<Phase>(ALL_PHASES));
   const [activeChapters, setActiveChapters] = useState<Set<string>>(() => new Set());
-  const [chaptersInitialized, setChaptersInitialized] = useState(false);
+  const [chaptersInit, setChaptersInit] = useState(false);
 
-  // initialize active chapters once we know what they are
+  const { data: graph } = useGraph();
+
+  // Debounce search → 300 ms before re-fetching SVG
   useEffect(() => {
-    if (chaptersInitialized || !graph) return;
+    const t = setTimeout(() => setDebouncedSearch(search), 300);
+    return () => clearTimeout(t);
+  }, [search]);
+
+  // Initialize chapter filter to "all chapters" once we know what they are.
+  useEffect(() => {
+    if (chaptersInit || !graph) return;
     const all = new Set<string>();
     for (const n of graph.nodes) if (n.chapter) all.add(n.chapter);
     setActiveChapters(all);
-    setChaptersInitialized(true);
-  }, [graph, chaptersInitialized]);
+    setChaptersInit(true);
+  }, [graph, chaptersInit]);
 
-  // route → state sync (also clears selection when URL drops the :id segment,
-  // e.g. browser Back from /nodes/:id to /nodes)
+  // URL → state sync (also clears selection when URL drops :id)
   useEffect(() => {
     const next = routeId || '';
     if (next !== selectedId) setSelectedId(next);
@@ -143,7 +52,6 @@ export default function Nodes() {
     return Array.from(set).sort();
   }, [graph]);
 
-  // counts per phase / chapter
   const phaseCounts = useMemo(() => {
     const counts: Record<string, number> = {};
     if (graph) for (const n of graph.nodes) counts[n.phase] = (counts[n.phase] || 0) + 1;
@@ -156,87 +64,89 @@ export default function Nodes() {
     return counts;
   }, [graph]);
 
-  // visible node set after filters
-  const visibleIds = useMemo(() => {
-    const set = new Set<string>();
-    if (!graph) return set;
-    const q = search.trim().toLowerCase();
-    for (const n of graph.nodes) {
-      if (!activePhases.has(n.phase)) continue;
-      // chapter filter only applies to nodes with a chapter; orphans (no source) always shown
-      if (n.chapter && !activeChapters.has(n.chapter)) continue;
-      if (q) {
-        const hay = `${n.id} ${n.leanDecl || ''}`.toLowerCase();
-        if (!hay.includes(q)) continue;
-      }
-      // skip orphans (no source) when not searched explicitly
-      if (!n.chapter && !q) continue;
-      set.add(n.id);
-    }
-    return set;
-  }, [graph, activePhases, activeChapters, search]);
+  const phasesArr = useMemo(() => Array.from(activePhases), [activePhases]);
+  const chaptersArr = useMemo(
+    () => (chaptersInit ? Array.from(activeChapters).sort() : []),
+    [activeChapters, chaptersInit],
+  );
 
-  // (re)mount cytoscape when graph or filter changes
-  useEffect(() => {
-    if (!graph || !containerRef.current) return;
-    if (cyRef.current) {
-      cyRef.current.destroy();
-      cyRef.current = null;
-    }
-    const elements = buildElements(graph, visibleIds);
-    const cy = cytoscape({
-      container: containerRef.current,
-      elements,
-      style: CY_STYLE,
-      layout: {
-        name: 'dagre',
-        rankDir: 'TB',
-        nodeSep: 14,
-        rankSep: 40,
-        edgeSep: 8,
-      } as unknown as cytoscape.LayoutOptions,
-      wheelSensitivity: 1,
-      minZoom: 0.1,
-      maxZoom: 4,
-    });
-    // Edges are visual structure only, not interactive targets.
-    cy.edges().unselectify();
-    cy.on('tap', 'node', (evt) => {
-      const id = evt.target.id() as string;
-      setSelectedId(id);
-      navigate(`/nodes/${encodeURIComponent(id)}`);
-    });
-    cy.on('tap', (evt) => {
-      // treat background AND edge taps as "deselect" so an edge click
-      // doesn't leave a stale selection ring or open a drawer.
-      if (evt.target === cy || (evt.target.isEdge && evt.target.isEdge())) {
-        setSelectedId('');
-        navigate('/nodes');
-      }
-    });
-    cyRef.current = cy;
-    return () => { cy.destroy(); cyRef.current = null; };
-  }, [graph, visibleIds, navigate]);
+  const { data: svgText, isFetching, isError } = useGraphSvg({
+    phases: phasesArr,
+    chapters: chaptersArr,
+    q: debouncedSearch,
+    enabled: chaptersInit,
+  });
 
-  // highlight selected + neighborhood
+  // Mount the SVG, init pan-zoom, attach click bridging.
   useEffect(() => {
-    const cy = cyRef.current;
-    if (!cy) return;
-    cy.elements().removeClass('highlighted faded');
+    const container = containerRef.current;
+    if (!container || !svgText) return;
+    container.innerHTML = svgText;
+    const svgEl = container.querySelector('svg') as SVGSVGElement | null;
+    if (!svgEl) return;
+
+    // Let it stretch to its parent box; preserve viewBox aspect.
+    svgEl.removeAttribute('width');
+    svgEl.removeAttribute('height');
+    svgEl.style.width = '100%';
+    svgEl.style.height = '100%';
+    svgEl.style.display = 'block';
+
+    const onClick = (e: MouseEvent) => {
+      let target = e.target as Element | null;
+      while (target && target !== svgEl) {
+        const id = target.getAttribute('id');
+        if (id && id.startsWith('node:')) {
+          const nodeId = id.slice('node:'.length);
+          setSelectedId(nodeId);
+          navigate(`/nodes/${encodeURIComponent(nodeId)}`);
+          return;
+        }
+        target = target.parentElement;
+      }
+      // Background click → deselect
+      setSelectedId('');
+      navigate('/nodes');
+    };
+    svgEl.addEventListener('click', onClick);
+
+    // Init pan-zoom
+    if (panZoomRef.current) {
+      try { panZoomRef.current.destroy(); } catch { /* ignore */ }
+      panZoomRef.current = null;
+    }
+    panZoomRef.current = svgPanZoom(svgEl, {
+      zoomEnabled: true,
+      controlIconsEnabled: false,
+      fit: true,
+      center: true,
+      mouseWheelZoomEnabled: true,
+      preventMouseEventsDefault: false,
+      minZoom: 0.2,
+      maxZoom: 8,
+      zoomScaleSensitivity: 0.4,
+    });
+
+    return () => {
+      svgEl.removeEventListener('click', onClick);
+      if (panZoomRef.current) {
+        try { panZoomRef.current.destroy(); } catch { /* ignore */ }
+        panZoomRef.current = null;
+      }
+    };
+  }, [svgText, navigate]);
+
+  // Highlight selected node in SVG
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    container.querySelectorAll('g.kip-node-selected').forEach(el =>
+      el.classList.remove('kip-node-selected'));
     if (!selectedId) return;
-    const sel = cy.getElementById(selectedId);
-    if (sel.empty()) return;
-    const neighborhood = sel.closedNeighborhood();
-    cy.elements().difference(neighborhood).addClass('faded');
-    neighborhood.addClass('highlighted');
-    sel.select();
-    // gently bring it into view if it's far off-screen
-    const bb = sel.boundingBox({});
-    const ext = cy.extent();
-    if (bb.x1 < ext.x1 || bb.x2 > ext.x2 || bb.y1 < ext.y1 || bb.y2 > ext.y2) {
-      cy.center(sel);
-    }
-  }, [selectedId, visibleIds]);
+    const sel = `#${(window.CSS && CSS.escape) ? CSS.escape('node:' + selectedId) : 'node\\:' + selectedId.replace(/[^a-zA-Z0-9_-]/g, c => '\\' + c)}`;
+    const el = container.querySelector(sel);
+    if (el) el.classList.add('kip-node-selected');
+  }, [selectedId, svgText]);
 
   const togglePhase = (p: Phase) => {
     setActivePhases(prev => {
@@ -253,22 +163,7 @@ export default function Nodes() {
     });
   };
 
-  if (!graph) {
-    return (
-      <div className={styles.canvasMissing}>
-        Loading graph data…
-      </div>
-    );
-  }
-
-  if (graph.nodes.length === 0) {
-    return (
-      <div className={styles.canvasMissing}>
-        State index is empty.<br/>
-        Run <code>python tools/kip-state/index.py</code> from the project root.
-      </div>
-    );
-  }
+  const totalNodes = graph?.nodes.length ?? 0;
 
   return (
     <div className={`${styles.root} ${selectedId ? styles.drawerOpen : ''}`}>
@@ -277,7 +172,7 @@ export default function Nodes() {
         <input
           className={styles.search}
           type="text"
-          placeholder="id or lean decl…"
+          placeholder="id or substring…"
           value={search}
           onChange={e => setSearch(e.target.value)}
         />
@@ -285,8 +180,9 @@ export default function Nodes() {
         <div className={styles.sidebarTitle}>Phase</div>
         <div className={styles.chips}>
           {ALL_PHASES.map(p => (
-            <span
+            <button
               key={p}
+              type="button"
               className={`${styles.chip} ${activePhases.has(p) ? styles.chipActive : ''}`}
               onClick={() => togglePhase(p)}
               title={PHASE_LABELS[p]}
@@ -294,30 +190,31 @@ export default function Nodes() {
               <span className={styles.chipDot} style={{ background: PHASE_COLORS[p] }} />
               {PHASE_LABELS[p]}
               <span className={styles.chipCount}>{phaseCounts[p] || 0}</span>
-            </span>
+            </button>
           ))}
         </div>
 
         <div className={styles.sidebarTitle}>Chapter</div>
         <div className={styles.chips}>
           {allChapters.map(c => (
-            <span
+            <button
               key={c}
+              type="button"
               className={`${styles.chip} ${activeChapters.has(c) ? styles.chipActive : ''}`}
               onClick={() => toggleChapter(c)}
             >
               {c}
               <span className={styles.chipCount}>{chapterCounts[c] || 0}</span>
-            </span>
+            </button>
           ))}
         </div>
 
         <div className={styles.sidebarTitle}>Shapes</div>
         <div className={styles.legend}>
-          <div className={styles.legendRow}><span className={`${styles.legendShape} ${styles.ellipse}`} />definition / notation</div>
-          <div className={styles.legendRow}><span className={`${styles.legendShape} ${styles.round}`} />theorem / prop / lemma / cor</div>
-          <div className={styles.legendRow}><span className={`${styles.legendShape} ${styles.rect}`} />axiom</div>
-          <div className={styles.legendRow}><span className={`${styles.legendShape} ${styles.hex}`} />remark / question / example</div>
+          <div className={styles.legendRow}>ellipse — definition / notation</div>
+          <div className={styles.legendRow}>rounded box — theorem / prop / lemma / cor / axiom</div>
+          <div className={styles.legendRow}>hexagon — remark</div>
+          <div className={styles.legendRow}>triangles — example / question</div>
         </div>
 
         <div className={styles.sidebarTitle}>Edges</div>
@@ -330,7 +227,11 @@ export default function Nodes() {
       <div className={styles.canvas}>
         <div className={styles.canvasInner} ref={containerRef} />
         <div className={styles.canvasOverlay}>
-          showing {visibleIds.size} / {graph.nodes.length} nodes
+          {isFetching && 'rendering… '}
+          {isError && 'render failed (check server log)'}
+          {!isFetching && !isError && (
+            <>graph rendered server-side via <code>dot</code> · {totalNodes} nodes total</>
+          )}
         </div>
       </div>
 

--- a/ui/client/src/views/Nodes.tsx
+++ b/ui/client/src/views/Nodes.tsx
@@ -232,9 +232,8 @@ export default function Nodes() {
         <div className={styles.sidebarTitle}>Shapes</div>
         <div className={styles.legend}>
           <div className={styles.legendRow}>ellipse — definition / notation</div>
-          <div className={styles.legendRow}>rounded box — theorem / prop / lemma / cor / axiom</div>
-          <div className={styles.legendRow}>hexagon — remark</div>
-          <div className={styles.legendRow}>triangles — example / question</div>
+          <div className={styles.legendRow}>rounded box — theorem / proposition / lemma / corollary</div>
+          <div className={styles.legendRow}>diamond — axiom</div>
         </div>
 
         <div className={styles.sidebarTitle}>Edges</div>

--- a/ui/client/src/views/Nodes.tsx
+++ b/ui/client/src/views/Nodes.tsx
@@ -9,6 +9,18 @@ import styles from './Nodes.module.css';
 
 const ALL_PHASES = [...PHASE_ORDER];
 
+const DRAWER_WIDTH_KEY = 'kip:drawerWidth';
+const DRAWER_MIN_PX = 320;
+const DRAWER_MAX_PX = 1100;
+const DRAWER_DEFAULT_PX = 420;
+
+function readSavedDrawerWidth(): number {
+  if (typeof window === 'undefined') return DRAWER_DEFAULT_PX;
+  const v = parseInt(window.localStorage.getItem(DRAWER_WIDTH_KEY) || '', 10);
+  if (Number.isFinite(v) && v >= DRAWER_MIN_PX && v <= DRAWER_MAX_PX) return v;
+  return DRAWER_DEFAULT_PX;
+}
+
 export default function Nodes() {
   const { id: routeId } = useParams<{ id?: string }>();
   const navigate = useNavigate();
@@ -28,6 +40,36 @@ export default function Nodes() {
   const [activePhases, setActivePhases] = useState<Set<Phase>>(() => new Set<Phase>(ALL_PHASES));
   const [activeChapters, setActiveChapters] = useState<Set<string>>(() => new Set());
   const [chaptersInit, setChaptersInit] = useState(false);
+  const [drawerWidth, setDrawerWidth] = useState<number>(readSavedDrawerWidth);
+
+  // Persist drawer width across page loads.
+  useEffect(() => {
+    try { window.localStorage.setItem(DRAWER_WIDTH_KEY, String(drawerWidth)); } catch { /* ignore */ }
+  }, [drawerWidth]);
+
+  const startDrawerResize = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const startX = e.clientX;
+    const startW = drawerWidth;
+    const onMove = (ev: MouseEvent) => {
+      // Drawer is anchored to the right; dragging the handle leftwards
+      // (smaller clientX) grows the drawer. Clamp to avoid degenerate widths.
+      const next = Math.max(DRAWER_MIN_PX, Math.min(DRAWER_MAX_PX, startW + (startX - ev.clientX)));
+      setDrawerWidth(next);
+    };
+    const onUp = () => {
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+    // Lock the cursor + disable text selection while dragging — without
+    // these, fast drags pick up arbitrary text on the page.
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+  };
 
   const { data: graph } = useGraph();
 
@@ -108,9 +150,9 @@ export default function Nodes() {
         }
         target = target.parentElement;
       }
-      // Background click → deselect
-      setSelectedId('');
-      navRef.current('/nodes');
+      // Background click is a no-op: closing the drawer should be an
+      // explicit action (the close button or Escape), since users routinely
+      // pan the canvas with click-drag and would otherwise lose context.
     };
     svgEl.addEventListener('click', onClick);
 
@@ -166,6 +208,40 @@ export default function Nodes() {
     const sel = `#${(window.CSS && CSS.escape) ? CSS.escape('node:' + selectedId) : 'node\\:' + selectedId.replace(/[^a-zA-Z0-9_-]/g, c => '\\' + c)}`;
     const el = container.querySelector(sel);
     if (el) el.classList.add('kip-node-selected');
+  }, [selectedId, svgText]);
+
+  // Highlight edges incident to the selected node. Edge group ids are emitted
+  // by the server as `edge:<from>-><to>` (where the DB direction is preserved
+  // even though DOT renders the arrow flipped). Outgoing in the data sense
+  // (from === selectedId) means "selectedId uses ..." and incoming
+  // (to === selectedId) means "... uses selectedId" — coloured separately so
+  // both flow directions are legible at a glance.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    container.querySelectorAll('g.kip-edge-uses, g.kip-edge-usedby').forEach(el => {
+      el.classList.remove('kip-edge-uses');
+      el.classList.remove('kip-edge-usedby');
+    });
+    if (!selectedId) return;
+    const edges = container.querySelectorAll<SVGGElement>('g.edge[id^="edge:"]');
+    edges.forEach(el => {
+      const id = el.getAttribute('id') || '';
+      const rest = id.slice('edge:'.length);
+      const arrow = rest.indexOf('->');
+      if (arrow < 0) return;
+      const from = rest.slice(0, arrow);
+      const to = rest.slice(arrow + 2);
+      if (from === selectedId) {
+        el.classList.add('kip-edge-uses');
+        // Re-append so the highlighted stroke paints over neighbouring
+        // edges instead of being hidden under them.
+        el.parentNode?.appendChild(el);
+      } else if (to === selectedId) {
+        el.classList.add('kip-edge-usedby');
+        el.parentNode?.appendChild(el);
+      }
+    });
   }, [selectedId, svgText]);
 
   const togglePhase = (p: Phase) => {
@@ -240,6 +316,14 @@ export default function Nodes() {
         <div className={styles.legend}>
           <div className={styles.legendRow}>top → bottom = build order</div>
           <div className={styles.legendRow}>arrow A → B reads "A is used by B"</div>
+          <div className={styles.legendRow}>
+            <span className={styles.legendSwatch} style={{ background: '#0366d6' }} />
+            on select: this node's <em>uses</em>
+          </div>
+          <div className={styles.legendRow}>
+            <span className={styles.legendSwatch} style={{ background: '#e36209' }} />
+            on select: <em>used by</em> this node
+          </div>
         </div>
       </aside>
 
@@ -255,7 +339,15 @@ export default function Nodes() {
       </div>
 
       {selectedId && (
-        <div className={styles.drawer}>
+        <div className={styles.drawer} style={{ width: drawerWidth }}>
+          <div
+            className={styles.drawerResize}
+            onMouseDown={startDrawerResize}
+            role="separator"
+            aria-orientation="vertical"
+            aria-label="Resize drawer"
+            title="Drag to resize"
+          />
           <NodeDetail
             nodeId={selectedId}
             onClose={() => { setSelectedId(''); navigate('/nodes'); }}

--- a/ui/client/src/views/Overview.tsx
+++ b/ui/client/src/views/Overview.tsx
@@ -1,38 +1,161 @@
-import { useAgents, useSummary } from '../hooks/useApi';
-import { fmtDuration, fmtTokens, fmtTime } from '../utils/format';
-import { STATUS_COLORS } from '../utils/constants';
+import { useNavigate } from 'react-router-dom';
+import { useGraph, useStateHealth, useSummary } from '../hooks/useApi';
+import { PHASE_COLORS, PHASE_ORDER, PHASE_LABELS } from '../utils/constants';
+import { fmtDuration } from '../utils/format';
+import type { NodeData, Phase } from '../types';
 import styles from './Overview.module.css';
 
+const STALE_DAYS = 14;
+
+function daysAgo(iso: string | null | undefined): number | null {
+  if (!iso) return null;
+  const t = Date.parse(iso);
+  if (isNaN(t)) return null;
+  return (Date.now() - t) / 86_400_000;
+}
+
+function isStaleInPhase(n: NodeData): boolean {
+  if (n.phase === 'proved') return false;
+  if (!n.chapter) return false;
+  const d = daysAgo(n.lastActivity);
+  return d == null || d >= STALE_DAYS;
+}
+
 export default function Overview() {
-  const { data: agents } = useAgents();
+  const navigate = useNavigate();
+  const { data: graph } = useGraph();
+  const { data: health } = useStateHealth();
   const { data: summary } = useSummary();
+
+  if (!health || !health.ok) {
+    return (
+      <div className={styles.root}>
+        <h2 className={styles.title}>State index unavailable</h2>
+        <div className={styles.empty}>
+          {health?.error || 'Run python tools/kip-state/index.py to build .kip/state.db.'}
+        </div>
+      </div>
+    );
+  }
+
+  const phaseCounts: Record<string, number> = { ...(health.phases || {}) };
+  const total = Object.values(phaseCounts).reduce((a, b) => a + b, 0) || 1;
+
+  const stale = (graph?.nodes || []).filter(isStaleInPhase)
+    .sort((a, b) => {
+      const da = daysAgo(a.lastActivity) ?? Number.POSITIVE_INFINITY;
+      const db = daysAgo(b.lastActivity) ?? Number.POSITIVE_INFINITY;
+      return db - da;
+    })
+    .slice(0, 20);
+
+  const indexedAt = health.meta?.indexed_at;
 
   return (
     <div className={styles.root}>
-      <h2 className={styles.title}>KIP Agent Dashboard</h2>
+      <h2 className={styles.title}>KIP — node lifecycle</h2>
 
-      {agents && agents.length > 0 && (
-        <div className={styles.section}>
-          <div className={styles.sectionLabel}>Agents</div>
-          <div className={styles.agentList}>
-            {agents.map(a => (
-              <div key={a.name} className={styles.agentCard}>
-                <span className={styles.agentName}>{a.name}</span>
-                <span className={styles.agentRuns}>{a.runCount} run{a.runCount !== 1 ? 's' : ''}</span>
-                {a.latestRun && <span className={styles.agentLatest}>latest: {fmtTime(a.latestRun)}</span>}
+      <div className={styles.section}>
+        <div className={styles.sectionLabel}>Phase distribution ({total} nodes)</div>
+        <div style={{ display: 'flex', height: 24, borderRadius: 4, overflow: 'hidden', border: '1px solid var(--border)' }}>
+          {PHASE_ORDER.map(p => {
+            const c = phaseCounts[p] || 0;
+            const pct = (c / total) * 100;
+            if (pct < 0.1) return null;
+            return (
+              <div key={p}
+                   title={`${PHASE_LABELS[p]}: ${c}`}
+                   style={{ background: PHASE_COLORS[p], flexBasis: `${pct}%`, display: 'flex',
+                            alignItems: 'center', justifyContent: 'center', color: 'white',
+                            fontSize: 11, fontWeight: 500, cursor: 'pointer' }}
+                   onClick={() => navigate('/nodes')}>
+                {pct >= 5 ? `${c}` : ''}
               </div>
-            ))}
+            );
+          })}
+        </div>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12, marginTop: 8, fontSize: 11, color: 'var(--text-secondary)' }}>
+          {PHASE_ORDER.map(p => (
+            <span key={p} style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+              <span style={{ width: 8, height: 8, borderRadius: '50%', background: PHASE_COLORS[p] }} />
+              {PHASE_LABELS[p]} <strong style={{ color: 'var(--text-primary)' }}>{phaseCounts[p] || 0}</strong>
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div className={styles.section}>
+        <div className={styles.sectionLabel}>State index</div>
+        <div className={styles.statsGrid}>
+          <div className={styles.stat}>
+            <span className={styles.statValue}>{health.counts?.nodes ?? '—'}</span>
+            <span className={styles.statLabel}>nodes</span>
+          </div>
+          <div className={styles.stat}>
+            <span className={styles.statValue}>{health.counts?.edges ?? '—'}</span>
+            <span className={styles.statLabel}>edges</span>
+          </div>
+          <div className={styles.stat}>
+            <span className={styles.statValue}>{health.counts?.lean_decls ?? '—'}</span>
+            <span className={styles.statLabel}>lean decls</span>
+          </div>
+          <div className={styles.stat}>
+            <span className={styles.statValue}>{health.counts?.agent_runs ?? '—'}</span>
+            <span className={styles.statLabel}>agent runs</span>
           </div>
         </div>
-      )}
+        {indexedAt && (
+          <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 8 }}>
+            Indexed at {new Date(indexedAt).toLocaleString()}
+          </div>
+        )}
+      </div>
 
-      {agents && agents.length === 0 && (
-        <div className={styles.empty}>No agent logs found. Run an agent to see logs here.</div>
-      )}
+      <div className={styles.section}>
+        <div className={styles.sectionLabel}>
+          Stale backlog · top {stale.length} nodes idle ≥ {STALE_DAYS} days
+        </div>
+        {stale.length === 0 ? (
+          <div className={styles.empty}>No stale nodes. Nice.</div>
+        ) : (
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th>id</th>
+                <th>kind</th>
+                <th>chapter</th>
+                <th>phase</th>
+                <th>idle</th>
+              </tr>
+            </thead>
+            <tbody>
+              {stale.map(n => {
+                const d = daysAgo(n.lastActivity);
+                return (
+                  <tr key={n.id}
+                      style={{ cursor: 'pointer' }}
+                      onClick={() => navigate(`/nodes/${encodeURIComponent(n.id)}`)}>
+                    <td>{n.id}</td>
+                    <td>{n.kind || '—'}</td>
+                    <td>{n.chapter || '—'}</td>
+                    <td>
+                      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+                        <span style={{ width: 8, height: 8, borderRadius: '50%', background: PHASE_COLORS[n.phase] }} />
+                        {PHASE_LABELS[n.phase]}
+                      </span>
+                    </td>
+                    <td>{d == null ? '∞' : `${Math.floor(d)}d`}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
 
       {summary && summary.sessionCount > 0 && (
         <div className={styles.section}>
-          <div className={styles.sectionLabel}>Totals</div>
+          <div className={styles.sectionLabel}>Agent activity totals</div>
           <div className={styles.statsGrid}>
             <div className={styles.stat}>
               <span className={styles.statValue}>{summary.sessionCount}</span>
@@ -46,37 +169,7 @@ export default function Overview() {
               <span className={styles.statValue}>${summary.totalCost.toFixed(2)}</span>
               <span className={styles.statLabel}>cost</span>
             </div>
-            <div className={styles.stat}>
-              <span className={styles.statValue}>{fmtTokens(summary.totalTokensIn)}</span>
-              <span className={styles.statLabel}>tokens in</span>
-            </div>
-            <div className={styles.stat}>
-              <span className={styles.statValue}>{fmtTokens(summary.totalTokensOut)}</span>
-              <span className={styles.statLabel}>tokens out</span>
-            </div>
           </div>
-        </div>
-      )}
-
-      {summary?.sessions && summary.sessions.length > 0 && (
-        <div className={styles.section}>
-          <div className={styles.sectionLabel}>Recent Sessions</div>
-          <table className={styles.table}>
-            <thead>
-              <tr><th>Time</th><th>Model</th><th>Duration</th><th>Turns</th><th>Cost</th></tr>
-            </thead>
-            <tbody>
-              {summary.sessions.slice().reverse().slice(0, 20).map((s, i) => (
-                <tr key={i}>
-                  <td>{fmtTime(s.timestamp)}</td>
-                  <td>{s.model}</td>
-                  <td>{fmtDuration(s.duration)}</td>
-                  <td>{s.turns}</td>
-                  <td>${s.cost.toFixed(3)}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
         </div>
       )}
     </div>

--- a/ui/server/package-lock.json
+++ b/ui/server/package-lock.json
@@ -11,9 +11,11 @@
         "@fastify/cors": "^9.0.1",
         "@fastify/static": "^7.0.4",
         "@fastify/websocket": "^10.0.1",
+        "better-sqlite3": "^11.10.0",
         "fastify": "^4.28.1"
       },
       "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^20.14.2",
         "tsx": "^4.15.4",
         "typescript": "^5.4.5"
@@ -595,6 +597,16 @@
         "node": ">=14"
       }
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
@@ -709,6 +721,57 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
@@ -717,6 +780,36 @@
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -771,6 +864,30 @@
         "node": ">= 8"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -778,6 +895,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/duplexify": {
@@ -860,6 +986,15 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/fast-content-type-parse": {
       "version": "1.1.0",
@@ -975,6 +1110,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/find-my-way": {
       "version": "8.2.2",
       "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-8.2.2.tgz",
@@ -1014,6 +1155,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1041,6 +1188,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "10.5.0",
@@ -1079,10 +1232,36 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ipaddr.js": {
@@ -1168,6 +1347,18 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -1183,6 +1374,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -1192,6 +1392,12 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/mnemonist": {
       "version": "0.39.6",
       "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.39.6.tgz",
@@ -1199,6 +1405,24 @@
       "license": "MIT",
       "dependencies": {
         "obliterator": "^2.0.1"
+      }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/obliterator": {
@@ -1309,6 +1533,33 @@
       ],
       "license": "MIT"
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/process-warning": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
@@ -1328,11 +1579,36 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
@@ -1502,6 +1778,51 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/sonic-boom": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
@@ -1640,6 +1961,43 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/thread-stream": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
@@ -1685,6 +2043,18 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/typescript": {

--- a/ui/server/package-lock.json
+++ b/ui/server/package-lock.json
@@ -12,10 +12,12 @@
         "@fastify/static": "^7.0.4",
         "@fastify/websocket": "^10.0.1",
         "better-sqlite3": "^11.10.0",
-        "fastify": "^4.28.1"
+        "fastify": "^4.28.1",
+        "js-yaml": "^4.1.1"
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.14.2",
         "tsx": "^4.15.4",
         "typescript": "^5.4.5"
@@ -607,6 +609,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
@@ -695,6 +704,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
@@ -1301,6 +1316,18 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/json-schema-ref-resolver": {

--- a/ui/server/package.json
+++ b/ui/server/package.json
@@ -11,9 +11,11 @@
     "@fastify/cors": "^9.0.1",
     "@fastify/static": "^7.0.4",
     "@fastify/websocket": "^10.0.1",
+    "better-sqlite3": "^11.10.0",
     "fastify": "^4.28.1"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20.14.2",
     "tsx": "^4.15.4",
     "typescript": "^5.4.5"

--- a/ui/server/package.json
+++ b/ui/server/package.json
@@ -12,10 +12,12 @@
     "@fastify/static": "^7.0.4",
     "@fastify/websocket": "^10.0.1",
     "better-sqlite3": "^11.10.0",
-    "fastify": "^4.28.1"
+    "fastify": "^4.28.1",
+    "js-yaml": "^4.1.1"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.14.2",
     "tsx": "^4.15.4",
     "typescript": "^5.4.5"

--- a/ui/server/src/index.ts
+++ b/ui/server/src/index.ts
@@ -10,6 +10,7 @@ import { register as registerProject } from './routes/project.js';
 import { register as registerAgents } from './routes/agents.js';
 import { register as registerLogs } from './routes/logs.js';
 import { register as registerSummary } from './routes/summary.js';
+import { register as registerNodes } from './routes/nodes.js';
 
 export interface ProjectPaths {
   projectPath: string;
@@ -62,6 +63,7 @@ export async function createServer(options: { projectPath: string; port: number 
   registerAgents(fastify, paths);
   registerLogs(fastify, paths);
   registerSummary(fastify, paths);
+  registerNodes(fastify, paths);
 
   await fastify.listen({ port, host: '0.0.0.0' });
   return fastify;

--- a/ui/server/src/routes/graph_svg.ts
+++ b/ui/server/src/routes/graph_svg.ts
@@ -7,6 +7,7 @@ interface NodeRow {
   id: string;
   kind: string | null;
   chapter: string | null;
+  subsection: string | null;
   phase: string;
 }
 
@@ -104,8 +105,11 @@ export function buildDot(nodes: NodeRow[], edges: EdgeRow[], filters: GraphFilte
              'margin="0.18,0.06"];');
   lines.push('  edge [color="#9aa1a9", arrowsize=0.7, penwidth=1.0];');
 
-  for (const n of nodes) {
-    if (!visible.has(n.id)) continue;
+  // Bucket visible nodes by chapter so we can emit each chapter as a Graphviz
+  // cluster (rounded box w/ chapter label). Within a cluster the global
+  // rankdir=TB still applies, so the dep→theorem flow is preserved; cross-
+  // cluster edges are emitted at top level after all clusters are closed.
+  const emitNode = (n: NodeRow) => {
     const fill = PHASE_COLORS[n.phase] || '#bbbbbb';
     const fontcolor = labelColorOn(fill);
     const shape = KIND_SHAPES[n.kind || ''] || 'ellipse';
@@ -119,8 +123,59 @@ export function buildDot(nodes: NodeRow[], edges: EdgeRow[], filters: GraphFilte
       `fontcolor=${escapeDot(fontcolor)}`,
       `class=${escapeDot('kip-node phase-' + n.phase + (n.kind ? ' kind-' + n.kind : ''))}`,
     ];
-    lines.push(`  ${escapeDot(n.id)} [${attrs.join(', ')}];`);
+    return `    ${escapeDot(n.id)} [${attrs.join(', ')}];`;
+  };
+
+  // Two-level bucketing: chapter → subsection → nodes. A null subsection
+  // means the node sits directly under \section (no \subsection layer in that
+  // chapter, e.g. leibniz-mahowald.tex), so it's emitted at chapter level
+  // rather than in a subsection sub-cluster. Iteration order follows the
+  // insertion order of the node list, which matches LaTeX reading order.
+  const byChapter = new Map<string, Map<string | null, NodeRow[]>>();
+  const orphans: NodeRow[] = [];
+  for (const n of nodes) {
+    if (!visible.has(n.id)) continue;
+    if (!n.chapter) { orphans.push(n); continue; }
+    let chapMap = byChapter.get(n.chapter);
+    if (!chapMap) { chapMap = new Map(); byChapter.set(n.chapter, chapMap); }
+    const key = n.subsection || null;
+    const list = chapMap.get(key);
+    if (list) list.push(n); else chapMap.set(key, [n]);
   }
+
+  let ci = 0;
+  const openCluster = (label: string, indent: string, fill: string, border: string, fontSize: number) => {
+    lines.push(`${indent}subgraph cluster_${ci++} {`);
+    lines.push(`${indent}  label=${escapeDot(label)};`);
+    lines.push(`${indent}  labeljust="l";`);
+    lines.push(`${indent}  labelloc="t";`);
+    lines.push(`${indent}  style="rounded,filled";`);
+    lines.push(`${indent}  fillcolor=${escapeDot(fill)};`);
+    lines.push(`${indent}  color=${escapeDot(border)};`);
+    lines.push(`${indent}  fontname="Helvetica,Arial,sans-serif";`);
+    lines.push(`${indent}  fontsize=${fontSize};`);
+    lines.push(`${indent}  fontcolor="#57606a";`);
+    lines.push(`${indent}  margin=10;`);
+  };
+
+  for (const [chapter, subMap] of byChapter) {
+    openCluster(chapter, '  ', '#f6f8fa', '#d0d7de', 12);
+    // Direct chapter-level nodes first (no subsection), then each subsection
+    // bucket as its own nested cluster. Chapter-direct nodes typically only
+    // appear when the chapter file has no \subsection at all.
+    const direct = subMap.get(null) || [];
+    for (const n of direct) lines.push(emitNode(n));
+    for (const [sub, ns] of subMap) {
+      if (sub === null) continue;
+      openCluster(sub, '    ', '#ffffff', '#bcc4cc', 11);
+      for (const n of ns) lines.push(`  ${emitNode(n)}`);
+      lines.push(`    }`);
+    }
+    lines.push(`  }`);
+  }
+  // Any chapter-less visible nodes (only when hideOrphans is disabled) sit at
+  // the top level so they still render.
+  for (const n of orphans) lines.push(emitNode(n));
 
   for (const e of edges) {
     if (!visible.has(e.from_node) || !visible.has(e.to_node)) continue;
@@ -140,6 +195,30 @@ export function buildDot(nodes: NodeRow[], edges: EdgeRow[], filters: GraphFilte
   return lines.join('\n');
 }
 
+// Graphviz emits <title> elements that browsers render as hover tooltips.
+// Strip the ones we don't want users to see:
+//   * cluster_N — internal subgraph names on chapter / subsection boxes
+//   * G        — the digraph name on the root graph group
+//   * edge titles (e.g. "from->to") — fine in theory but become a nuisance
+//     when zoomed in and the edge path is wide enough to reliably trigger
+//     hover; the user explicitly opted out
+// Node titles (the actual node id) are kept — those are useful on hover.
+function stripInternalTitles(svg: string): string {
+  return svg
+    .replace(
+      /(<g id="clust\d+"[^>]*class="cluster"[^>]*>\s*)<title>[^<]*<\/title>\s*/g,
+      '$1',
+    )
+    .replace(
+      /(<g id="graph\d+"[^>]*class="graph"[^>]*>\s*)<title>[^<]*<\/title>\s*/g,
+      '$1',
+    )
+    .replace(
+      /(<g id="edge[^"]*"[^>]*class="edge"[^>]*>\s*)<title>[^<]*<\/title>\s*/g,
+      '$1',
+    );
+}
+
 export async function renderSvg(dot: string, timeoutMs = 8000): Promise<string> {
   return new Promise((resolve, reject) => {
     const proc = spawn('dot', ['-Tsvg'], { stdio: ['pipe', 'pipe', 'pipe'] });
@@ -155,7 +234,7 @@ export async function renderSvg(dot: string, timeoutMs = 8000): Promise<string> 
     proc.on('close', (code) => {
       clearTimeout(timer);
       if (code !== 0) reject(new Error(`dot exited ${code}: ${stderr.slice(0, 400)}`));
-      else resolve(stdout);
+      else resolve(stripInternalTitles(stdout));
     });
     proc.stdin.end(dot);
   });

--- a/ui/server/src/routes/graph_svg.ts
+++ b/ui/server/src/routes/graph_svg.ts
@@ -23,6 +23,8 @@ const PHASE_COLORS: Record<string, string> = {
   proved:      '#28a745',
 };
 
+// Three shape buckets only — non-blueprint kinds (remark/example/question) are
+// filtered out upstream, so we don't need shapes for them.
 const KIND_SHAPES: Record<string, string> = {
   definition:  'ellipse',
   notation:    'ellipse',
@@ -30,11 +32,17 @@ const KIND_SHAPES: Record<string, string> = {
   proposition: 'box',
   lemma:       'box',
   corollary:   'box',
-  axiom:       'box',
-  remark:      'hexagon',
-  question:    'invtriangle',
-  example:     'triangle',
+  axiom:       'diamond',
 };
+
+// Kinds that belong on the formalization roadmap. Remarks, examples, and
+// questions are commentary; they're filtered out of the dependency graph and
+// sidebar counts (but remain reachable via direct /api/nodes/:id lookups).
+export const BLUEPRINT_KINDS: ReadonlySet<string> = new Set([
+  'definition', 'notation',
+  'theorem', 'proposition', 'lemma', 'corollary',
+  'axiom',
+]);
 
 // Pick a contrasting label color for a given fill — keep it readable.
 function labelColorOn(bg: string): string {
@@ -71,6 +79,9 @@ export function buildDot(nodes: NodeRow[], edges: EdgeRow[], filters: GraphFilte
 
   const visible = new Set<string>();
   for (const n of nodes) {
+    // Defense in depth — routes already drop non-blueprint kinds, but if a
+    // caller bypasses that, the DOT shouldn't suddenly grow remark hexagons.
+    if (n.kind && !BLUEPRINT_KINDS.has(n.kind)) continue;
     if (phaseFilter && !phaseFilter.has(n.phase)) continue;
     if (chapterFilter && n.chapter && !chapterFilter.has(n.chapter)) continue;
     if (hideOrphans && !n.chapter && !q) continue;

--- a/ui/server/src/routes/graph_svg.ts
+++ b/ui/server/src/routes/graph_svg.ts
@@ -13,7 +13,6 @@ interface NodeRow {
 interface EdgeRow {
   from_node: string;
   to_node: string;
-  confirmed: number;
 }
 
 const PHASE_COLORS: Record<string, string> = {
@@ -114,10 +113,16 @@ export function buildDot(nodes: NodeRow[], edges: EdgeRow[], filters: GraphFilte
 
   for (const e of edges) {
     if (!visible.has(e.from_node) || !visible.has(e.to_node)) continue;
+    // DB semantic: from_node has \uses{to_node}, i.e. from is upper, to is
+    // lower. We flip direction in DOT so low-level definitions land at the
+    // top (source rank) and the theorems they feed land at the bottom (sink
+    // rank). Visually, arrows point downward in completion order:
+    //     definition  ──▶  lemma  ──▶  theorem
+    // The `id`/`eid` keeps the DB direction so SVG-side lookups stay
+    // consistent with the edges table.
     const eid = `edge:${e.from_node}->${e.to_node}`;
-    const style = e.confirmed ? 'solid' : 'dashed';
-    lines.push(`  ${escapeDot(e.from_node)} -> ${escapeDot(e.to_node)} ` +
-               `[id=${escapeDot(eid)}, style=${style}];`);
+    lines.push(`  ${escapeDot(e.to_node)} -> ${escapeDot(e.from_node)} ` +
+               `[id=${escapeDot(eid)}];`);
   }
   lines.push('}');
 

--- a/ui/server/src/routes/graph_svg.ts
+++ b/ui/server/src/routes/graph_svg.ts
@@ -1,0 +1,146 @@
+// Render the dependency DAG as SVG by piping a DOT description through the
+// system `dot` binary (Graphviz). Mirrors what leanblueprint does at build
+// time, except we do it on demand so we can apply UI filters server-side.
+import { spawn } from 'child_process';
+
+interface NodeRow {
+  id: string;
+  kind: string | null;
+  chapter: string | null;
+  phase: string;
+}
+
+interface EdgeRow {
+  from_node: string;
+  to_node: string;
+  confirmed: number;
+}
+
+const PHASE_COLORS: Record<string, string> = {
+  drafted:     '#c9ccd1',
+  nl_reviewed: '#6f42c1',
+  bound:       '#0366d6',
+  aligned:     '#e36209',
+  proved:      '#28a745',
+};
+
+const KIND_SHAPES: Record<string, string> = {
+  definition:  'ellipse',
+  notation:    'ellipse',
+  theorem:     'box',          // round-rectangle in DOT terms
+  proposition: 'box',
+  lemma:       'box',
+  corollary:   'box',
+  axiom:       'box',
+  remark:      'hexagon',
+  question:    'invtriangle',
+  example:     'triangle',
+};
+
+// Pick a contrasting label color for a given fill — keep it readable.
+function labelColorOn(bg: string): string {
+  // simple luminance check
+  const r = parseInt(bg.slice(1, 3), 16);
+  const g = parseInt(bg.slice(3, 5), 16);
+  const b = parseInt(bg.slice(5, 7), 16);
+  const lum = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return lum > 0.65 ? '#1a1a1a' : '#ffffff';
+}
+
+function lastSegment(id: string): string {
+  const parts = id.split(':');
+  return parts[parts.length - 1] || id;
+}
+
+// DOT identifiers must be quoted strings; escape embedded quotes/backslashes.
+function escapeDot(s: string): string {
+  return '"' + s.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"';
+}
+
+export interface GraphFilters {
+  phases?: Set<string>;
+  chapters?: Set<string>;
+  search?: string;
+  hideOrphans?: boolean;
+}
+
+export function buildDot(nodes: NodeRow[], edges: EdgeRow[], filters: GraphFilters = {}): string {
+  const phaseFilter = filters.phases;
+  const chapterFilter = filters.chapters;
+  const q = (filters.search || '').trim().toLowerCase();
+  const hideOrphans = filters.hideOrphans !== false;  // default true
+
+  const visible = new Set<string>();
+  for (const n of nodes) {
+    if (phaseFilter && !phaseFilter.has(n.phase)) continue;
+    if (chapterFilter && n.chapter && !chapterFilter.has(n.chapter)) continue;
+    if (hideOrphans && !n.chapter && !q) continue;
+    if (q) {
+      if (!n.id.toLowerCase().includes(q)) continue;
+    }
+    visible.add(n.id);
+  }
+
+  const lines: string[] = [];
+  lines.push('digraph G {');
+  lines.push('  rankdir=TB;');
+  lines.push('  bgcolor="transparent";');
+  lines.push('  pad="0.4";');
+  lines.push('  nodesep=0.3;');
+  lines.push('  ranksep=0.55;');
+  lines.push('  splines=spline;');
+  lines.push('  node [fontname="Helvetica,Arial,sans-serif", fontsize=11, ' +
+             'style="filled,setlinewidth(1)", color="#00000033", penwidth=1, ' +
+             'margin="0.18,0.06"];');
+  lines.push('  edge [color="#9aa1a9", arrowsize=0.7, penwidth=1.0];');
+
+  for (const n of nodes) {
+    if (!visible.has(n.id)) continue;
+    const fill = PHASE_COLORS[n.phase] || '#bbbbbb';
+    const fontcolor = labelColorOn(fill);
+    const shape = KIND_SHAPES[n.kind || ''] || 'ellipse';
+    const label = lastSegment(n.id);
+    const attrs = [
+      `id=${escapeDot('node:' + n.id)}`,            // becomes `id` on <g> in SVG
+      `label=${escapeDot(label)}`,
+      `tooltip=${escapeDot(n.id)}`,
+      `shape=${shape}`,
+      `fillcolor=${escapeDot(fill)}`,
+      `fontcolor=${escapeDot(fontcolor)}`,
+      `class=${escapeDot('kip-node phase-' + n.phase + (n.kind ? ' kind-' + n.kind : ''))}`,
+    ];
+    lines.push(`  ${escapeDot(n.id)} [${attrs.join(', ')}];`);
+  }
+
+  for (const e of edges) {
+    if (!visible.has(e.from_node) || !visible.has(e.to_node)) continue;
+    const eid = `edge:${e.from_node}->${e.to_node}`;
+    const style = e.confirmed ? 'solid' : 'dashed';
+    lines.push(`  ${escapeDot(e.from_node)} -> ${escapeDot(e.to_node)} ` +
+               `[id=${escapeDot(eid)}, style=${style}];`);
+  }
+  lines.push('}');
+
+  return lines.join('\n');
+}
+
+export async function renderSvg(dot: string, timeoutMs = 8000): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('dot', ['-Tsvg'], { stdio: ['pipe', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    const timer = setTimeout(() => {
+      proc.kill('SIGKILL');
+      reject(new Error(`dot timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    proc.stdout.on('data', (b) => { stdout += b.toString(); });
+    proc.stderr.on('data', (b) => { stderr += b.toString(); });
+    proc.on('error', (err) => { clearTimeout(timer); reject(err); });
+    proc.on('close', (code) => {
+      clearTimeout(timer);
+      if (code !== 0) reject(new Error(`dot exited ${code}: ${stderr.slice(0, 400)}`));
+      else resolve(stdout);
+    });
+    proc.stdin.end(dot);
+  });
+}

--- a/ui/server/src/routes/nodes.ts
+++ b/ui/server/src/routes/nodes.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import Database from 'better-sqlite3';
 import type { FastifyInstance } from 'fastify';
 import type { ProjectPaths } from '../index.js';
+import { buildDot, renderSvg, type GraphFilters } from './graph_svg.js';
 
 interface NodeRow {
   id: string;
@@ -241,6 +242,41 @@ export function register(fastify: FastifyInstance, paths: ProjectPaths) {
       confirmed: !!r.confirmed,
     }));
   });
+
+  // Server-rendered SVG of the dependency DAG via Graphviz `dot`. Filters
+  // (phases, chapters, q) are honored so the returned SVG only contains the
+  // visible subset — keeps client-side payload small and lets layout focus
+  // on what's shown.
+  fastify.get<{ Querystring: { phases?: string; chapters?: string; q?: string; orphans?: string } }>(
+    '/api/graph/svg',
+    async (req, reply) => {
+      const db = openDb(projectPath);
+      if (!db) {
+        reply.status(503);
+        return { error: 'state.db not built' };
+      }
+      const nodes = db.prepare("SELECT id, kind, chapter, phase FROM nodes").all() as
+        { id: string; kind: string | null; chapter: string | null; phase: string }[];
+      const edges = db.prepare("SELECT from_node, to_node, confirmed FROM edges").all() as
+        { from_node: string; to_node: string; confirmed: number }[];
+
+      const filters: GraphFilters = {};
+      if (req.query.phases) filters.phases = new Set(req.query.phases.split(',').filter(Boolean));
+      if (req.query.chapters) filters.chapters = new Set(req.query.chapters.split(',').filter(Boolean));
+      if (req.query.q) filters.search = req.query.q;
+      if (req.query.orphans === '1') filters.hideOrphans = false;
+
+      const dot = buildDot(nodes, edges, filters);
+      try {
+        const svg = await renderSvg(dot);
+        reply.type('image/svg+xml').header('cache-control', 'no-store');
+        return svg;
+      } catch (err: unknown) {
+        reply.status(500);
+        return { error: String((err as Error)?.message || err) };
+      }
+    },
+  );
 
   // Combined payload sized for one round-trip into the DAG view.
   fastify.get('/api/graph', async () => {

--- a/ui/server/src/routes/nodes.ts
+++ b/ui/server/src/routes/nodes.ts
@@ -464,8 +464,37 @@ export function register(fastify: FastifyInstance, paths: ProjectPaths) {
     ).all(id) as { from_node: string }[];
 
     const leanDecl = row.lean_decl
-      ? db.prepare("SELECT * FROM lean_decls WHERE name = ?").get(row.lean_decl)
+      ? db.prepare("SELECT * FROM lean_decls WHERE name = ?").get(row.lean_decl) as
+          { name: string; file: string; line_start: number; line_end: number; sorry_count: number } | undefined
       : null;
+
+    // Slurp the source span so the dashboard can show the Lean code beside
+    // the NL statement during alignment review. lean_decls.file is stored as
+    // a project-root-relative path (e.g. "KIP/Foundations/Foo.lean"); resolve
+    // and refuse anything that escapes the project root, same shape as the
+    // NL excerpt below.
+    let leanSource: string | null = null;
+    if (leanDecl && leanDecl.file && leanDecl.line_start && leanDecl.line_end) {
+      const fileAbs = path.isAbsolute(leanDecl.file)
+        ? leanDecl.file
+        : path.join(projectPath, leanDecl.file);
+      const resolved = path.resolve(fileAbs);
+      const projectAbs = path.resolve(projectPath);
+      const inside = resolved === projectAbs || resolved.startsWith(projectAbs + path.sep);
+      if (inside) {
+        try {
+          const text = fs.readFileSync(resolved, 'utf-8');
+          const lines = text.split('\n');
+          const start = Math.max(0, leanDecl.line_start - 1);
+          // line_end is inclusive in the indexer; cap at file length so a
+          // stale cache (file shrunk since last index) doesn't blow up.
+          const end = Math.max(start, Math.min(lines.length, leanDecl.line_end));
+          leanSource = lines.slice(start, end).join('\n');
+        } catch {
+          leanSource = null;
+        }
+      }
+    }
 
     const runs = db.prepare(
       `SELECT ar.id, ar.agent, ar.started_at, ar.completed_at, ar.status,
@@ -516,6 +545,7 @@ export function register(fastify: FastifyInstance, paths: ProjectPaths) {
       uses: usesEdges.map(e => ({ id: e.to_node })),
       usedBy: usedByEdges.map(e => ({ id: e.from_node })),
       leanDecl,
+      leanSource,
       runs,
       nlExcerpt,
       nlRendered,

--- a/ui/server/src/routes/nodes.ts
+++ b/ui/server/src/routes/nodes.ts
@@ -1,0 +1,311 @@
+import fs from 'fs';
+import path from 'path';
+import Database from 'better-sqlite3';
+import type { FastifyInstance } from 'fastify';
+import type { ProjectPaths } from '../index.js';
+
+interface NodeRow {
+  id: string;
+  kind: string | null;
+  chapter: string | null;
+  source_file: string | null;
+  source_line: number | null;
+  lean_decl: string | null;
+  leanok: number;
+  nl_hash: string | null;
+  nl_reviewed: number;
+  bound: number;
+  aligned: number;
+  proved: number;
+  nl_reviewer: string | null;
+  align_reviewer: string | null;
+  aligned_at: string | null;
+  last_activity: string | null;
+  phase: string;
+}
+
+interface EdgeRow {
+  from_node: string;
+  to_node: string;
+  source: string;
+  confirmed: number;
+}
+
+let dbInstance: Database.Database | null = null;
+let dbPath: string | null = null;
+let dbMtime: number = 0;
+
+// nodeId → absolute path of the chapter HTML containing it.
+// Built lazily (and rebuilt if `blueprint/web` mtime changes).
+let renderedIndex: Map<string, string> | null = null;
+let renderedIndexBase: string | null = null;
+let renderedIndexMtime: number = 0;
+
+function buildRenderedIndex(projectPath: string): Map<string, string> {
+  const map = new Map<string, string>();
+  const webDir = path.join(projectPath, 'blueprint', 'web');
+  if (!fs.existsSync(webDir)) return map;
+  const files = fs.readdirSync(webDir).filter(f => f.startsWith('sec-') && f.endsWith('.html'));
+  const re = /<div class="[^"]*_thmwrapper[^"]*" id="([^"]+)"/g;
+  for (const f of files) {
+    const full = path.join(webDir, f);
+    let text: string;
+    try { text = fs.readFileSync(full, 'utf-8'); } catch { continue; }
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(text)) !== null) {
+      if (!map.has(m[1])) map.set(m[1], full);
+    }
+  }
+  return map;
+}
+
+function getRenderedIndex(projectPath: string): Map<string, string> {
+  const webDir = path.join(projectPath, 'blueprint', 'web');
+  let mtime = 0;
+  if (fs.existsSync(webDir)) {
+    try { mtime = fs.statSync(webDir).mtimeMs; } catch { mtime = 0; }
+  }
+  if (renderedIndex && renderedIndexBase === webDir && renderedIndexMtime === mtime) {
+    return renderedIndex;
+  }
+  renderedIndex = buildRenderedIndex(projectPath);
+  renderedIndexBase = webDir;
+  renderedIndexMtime = mtime;
+  return renderedIndex;
+}
+
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Find the matching </div> for a <div...> opened at `openEnd` (one past >).
+function findClosingDiv(html: string, openEnd: number): number {
+  let i = openEnd;
+  let depth = 1;
+  while (i < html.length && depth > 0) {
+    const next = html.indexOf('<', i);
+    if (next === -1) return -1;
+    if (html.startsWith('</div', next)) {
+      depth--;
+      if (depth === 0) return next;
+      i = html.indexOf('>', next) + 1;
+    } else if (html.startsWith('<div', next)) {
+      depth++;
+      i = html.indexOf('>', next) + 1;
+    } else {
+      i = next + 1;
+    }
+  }
+  return -1;
+}
+
+interface RenderedNode {
+  caption: string;
+  label: string;
+  contentHtml: string;
+}
+
+function extractRenderedNode(html: string, nodeId: string): RenderedNode | null {
+  const startRe = new RegExp(`<div class="([^"]*)_thmwrapper[^"]*" id="${escapeRe(nodeId)}">`);
+  const sm = startRe.exec(html);
+  if (!sm) return null;
+  const kindClass = sm[1]; // e.g. "definition" / "theorem" / "remark"
+  const wrapperEnd = findClosingDiv(html, sm.index + sm[0].length);
+  const wrapper = wrapperEnd === -1 ? html.slice(sm.index) : html.slice(sm.index, wrapperEnd);
+
+  const capRe = new RegExp(`<span class="${kindClass}_thmcaption">\\s*([^<]+?)\\s*</span>`);
+  const lblRe = new RegExp(`<span class="${kindClass}_thmlabel">\\s*([^<]+?)\\s*</span>`);
+  const contStartRe = new RegExp(`<div class="${kindClass}_thmcontent">`);
+  const cm = capRe.exec(wrapper);
+  const lm = lblRe.exec(wrapper);
+  const csm = contStartRe.exec(wrapper);
+  let contentHtml = '';
+  if (csm) {
+    const innerStart = csm.index + csm[0].length;
+    const innerEnd = findClosingDiv(wrapper, innerStart);
+    contentHtml = innerEnd === -1 ? wrapper.slice(innerStart) : wrapper.slice(innerStart, innerEnd);
+  }
+  return {
+    caption: cm ? cm[1].trim() : '',
+    label: lm ? lm[1].trim() : '',
+    contentHtml,
+  };
+}
+
+function getRenderedNode(projectPath: string, nodeId: string): RenderedNode | null {
+  const idx = getRenderedIndex(projectPath);
+  const file = idx.get(nodeId);
+  if (!file) return null;
+  let text: string;
+  try { text = fs.readFileSync(file, 'utf-8'); } catch { return null; }
+  return extractRenderedNode(text, nodeId);
+}
+
+function openDb(projectPath: string): Database.Database | null {
+  const candidate = path.join(projectPath, '.kip', 'state.db');
+  if (!fs.existsSync(candidate)) return null;
+  const stat = fs.statSync(candidate);
+  if (dbInstance && dbPath === candidate && dbMtime === stat.mtimeMs) {
+    return dbInstance;
+  }
+  if (dbInstance) {
+    try { dbInstance.close(); } catch { /* ignore */ }
+  }
+  dbInstance = new Database(candidate, { readonly: true, fileMustExist: true });
+  dbPath = candidate;
+  dbMtime = stat.mtimeMs;
+  return dbInstance;
+}
+
+function shapeNode(r: NodeRow) {
+  return {
+    id: r.id,
+    kind: r.kind,
+    chapter: r.chapter,
+    sourceFile: r.source_file,
+    sourceLine: r.source_line,
+    leanDecl: r.lean_decl,
+    leanok: !!r.leanok,
+    nlHash: r.nl_hash,
+    flags: {
+      nlReviewed: !!r.nl_reviewed,
+      bound: !!r.bound,
+      aligned: !!r.aligned,
+      proved: !!r.proved,
+    },
+    nlReviewer: r.nl_reviewer,
+    alignReviewer: r.align_reviewer,
+    alignedAt: r.aligned_at,
+    lastActivity: r.last_activity,
+    phase: r.phase,
+  };
+}
+
+export function register(fastify: FastifyInstance, paths: ProjectPaths) {
+  const { projectPath } = paths;
+
+  fastify.get('/api/state/health', async () => {
+    const db = openDb(projectPath);
+    if (!db) {
+      return {
+        ok: false,
+        error: 'No .kip/state.db found. Run: python tools/kip-state/index.py',
+      };
+    }
+    const meta = db.prepare("SELECT key, value FROM meta").all() as { key: string; value: string }[];
+    const counts = {
+      nodes: (db.prepare("SELECT count(*) AS c FROM nodes").get() as { c: number }).c,
+      edges: (db.prepare("SELECT count(*) AS c FROM edges").get() as { c: number }).c,
+      lean_decls: (db.prepare("SELECT count(*) AS c FROM lean_decls").get() as { c: number }).c,
+      agent_runs: (db.prepare("SELECT count(*) AS c FROM agent_runs").get() as { c: number }).c,
+    };
+    const phases = db.prepare(
+      "SELECT phase, count(*) AS c FROM nodes GROUP BY phase"
+    ).all() as { phase: string; c: number }[];
+    return {
+      ok: true,
+      meta: Object.fromEntries(meta.map(m => [m.key, m.value])),
+      counts,
+      phases: Object.fromEntries(phases.map(p => [p.phase, p.c])),
+    };
+  });
+
+  fastify.get('/api/nodes', async () => {
+    const db = openDb(projectPath);
+    if (!db) return [];
+    const rows = db.prepare(
+      "SELECT * FROM nodes ORDER BY phase, id"
+    ).all() as NodeRow[];
+    return rows.map(shapeNode);
+  });
+
+  fastify.get('/api/edges', async () => {
+    const db = openDb(projectPath);
+    if (!db) return [];
+    const rows = db.prepare(
+      "SELECT from_node, to_node, source, confirmed FROM edges"
+    ).all() as EdgeRow[];
+    return rows.map(r => ({
+      from: r.from_node,
+      to: r.to_node,
+      source: r.source,
+      confirmed: !!r.confirmed,
+    }));
+  });
+
+  // Combined payload sized for one round-trip into the DAG view.
+  fastify.get('/api/graph', async () => {
+    const db = openDb(projectPath);
+    if (!db) return { nodes: [], edges: [] };
+    const nodes = (db.prepare("SELECT * FROM nodes ORDER BY id").all() as NodeRow[]).map(shapeNode);
+    const edges = (db.prepare("SELECT from_node, to_node, source, confirmed FROM edges").all() as EdgeRow[])
+      .map(r => ({ from: r.from_node, to: r.to_node, source: r.source, confirmed: !!r.confirmed }));
+    return { nodes, edges };
+  });
+
+  fastify.get<{ Params: { id: string } }>('/api/nodes/:id', async (req, reply) => {
+    const db = openDb(projectPath);
+    if (!db) return reply.status(503).send({ error: 'state.db not built' });
+    const id = req.params.id;
+    const row = db.prepare("SELECT * FROM nodes WHERE id = ?").get(id) as NodeRow | undefined;
+    if (!row) return reply.status(404).send({ error: 'Node not found' });
+
+    const comments = db.prepare(
+      "SELECT idx, topic, text, by, at FROM node_comments WHERE node_id = ? ORDER BY idx"
+    ).all(id);
+
+    const usesEdges = db.prepare(
+      "SELECT to_node, confirmed FROM edges WHERE from_node = ? ORDER BY to_node"
+    ).all(id) as { to_node: string; confirmed: number }[];
+
+    const usedByEdges = db.prepare(
+      "SELECT from_node, confirmed FROM edges WHERE to_node = ? ORDER BY from_node"
+    ).all(id) as { from_node: string; confirmed: number }[];
+
+    const leanDecl = row.lean_decl
+      ? db.prepare("SELECT * FROM lean_decls WHERE name = ?").get(row.lean_decl)
+      : null;
+
+    const runs = db.prepare(
+      `SELECT ar.id, ar.agent, ar.started_at, ar.completed_at, ar.status,
+              ar.model, ar.hint_file, ar.cost_usd, ar.duration_ms, ar.num_turns,
+              ar.summary, ar.log_path
+         FROM agent_runs ar
+         JOIN agent_run_nodes arn ON arn.run_id = ar.id
+        WHERE arn.node_id = ?
+        ORDER BY ar.started_at DESC`
+    ).all(id);
+
+    let nlExcerpt: string | null = null;
+    if (row.source_file && row.source_line) {
+      try {
+        const text = fs.readFileSync(row.source_file, 'utf-8');
+        const lines = text.split('\n');
+        const start = Math.max(0, row.source_line - 1);
+        // Read until matching \end{kind} or 80-line cap, whichever first.
+        const endRe = new RegExp(`\\\\end\\{${row.kind || '\\w+'}\\*?\\}`);
+        let end = start;
+        for (let i = start; i < Math.min(lines.length, start + 80); i++) {
+          end = i;
+          if (endRe.test(lines[i])) break;
+        }
+        nlExcerpt = lines.slice(start, end + 1).join('\n');
+      } catch {
+        nlExcerpt = null;
+      }
+    }
+
+    const nlRendered = getRenderedNode(projectPath, id);
+
+    return {
+      ...shapeNode(row),
+      comments,
+      uses: usesEdges.map(e => ({ id: e.to_node, confirmed: !!e.confirmed })),
+      usedBy: usedByEdges.map(e => ({ id: e.from_node, confirmed: !!e.confirmed })),
+      leanDecl,
+      runs,
+      nlExcerpt,
+      nlRendered,
+    };
+  });
+}

--- a/ui/server/src/routes/nodes.ts
+++ b/ui/server/src/routes/nodes.ts
@@ -61,9 +61,18 @@ function buildRenderedIndex(projectPath: string): Map<string, string> {
 
 function getRenderedIndex(projectPath: string): Map<string, string> {
   const webDir = path.join(projectPath, 'blueprint', 'web');
+  // Use max(mtime) across the actual sec-*.html files. The directory's own
+  // mtime only changes on entry add/remove, so rebuilding blueprint web
+  // (which rewrites file contents in place) wouldn't otherwise invalidate.
   let mtime = 0;
   if (fs.existsSync(webDir)) {
-    try { mtime = fs.statSync(webDir).mtimeMs; } catch { mtime = 0; }
+    try {
+      for (const f of fs.readdirSync(webDir)) {
+        if (!f.startsWith('sec-') || !f.endsWith('.html')) continue;
+        const m = fs.statSync(path.join(webDir, f)).mtimeMs;
+        if (m > mtime) mtime = m;
+      }
+    } catch { mtime = 0; }
   }
   if (renderedIndex && renderedIndexBase === webDir && renderedIndexMtime === mtime) {
     return renderedIndex;
@@ -278,20 +287,32 @@ export function register(fastify: FastifyInstance, paths: ProjectPaths) {
 
     let nlExcerpt: string | null = null;
     if (row.source_file && row.source_line) {
-      try {
-        const text = fs.readFileSync(row.source_file, 'utf-8');
-        const lines = text.split('\n');
-        const start = Math.max(0, row.source_line - 1);
-        // Read until matching \end{kind} or 80-line cap, whichever first.
-        const endRe = new RegExp(`\\\\end\\{${row.kind || '\\w+'}\\*?\\}`);
-        let end = start;
-        for (let i = start; i < Math.min(lines.length, start + 80); i++) {
-          end = i;
-          if (endRe.test(lines[i])) break;
+      // source_file comes from the SQLite cache, which itself derives from
+      // chapter .tex paths. Refuse anything that resolves outside the project
+      // root before touching the filesystem — defends against a poisoned DB.
+      const resolved = path.resolve(row.source_file);
+      const projectAbs = path.resolve(projectPath);
+      const inside = resolved === projectAbs || resolved.startsWith(projectAbs + path.sep);
+      if (inside) {
+        try {
+          const text = fs.readFileSync(resolved, 'utf-8');
+          const lines = text.split('\n');
+          const start = Math.max(0, row.source_line - 1);
+          // Read until matching \end{kind} or 80-line cap, whichever first.
+          // Escape kind defensively in case YAML ever contains regex metas.
+          const escapedKind = row.kind
+            ? row.kind.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+            : '\\w+';
+          const endRe = new RegExp(`\\\\end\\{${escapedKind}\\*?\\}`);
+          let end = start;
+          for (let i = start; i < Math.min(lines.length, start + 80); i++) {
+            end = i;
+            if (endRe.test(lines[i])) break;
+          }
+          nlExcerpt = lines.slice(start, end + 1).join('\n');
+        } catch {
+          nlExcerpt = null;
         }
-        nlExcerpt = lines.slice(start, end + 1).join('\n');
-      } catch {
-        nlExcerpt = null;
       }
     }
 

--- a/ui/server/src/routes/nodes.ts
+++ b/ui/server/src/routes/nodes.ts
@@ -29,7 +29,6 @@ interface EdgeRow {
   from_node: string;
   to_node: string;
   source: string;
-  confirmed: number;
 }
 
 let dbInstance: Database.Database | null = null;
@@ -151,6 +150,49 @@ function getRenderedNode(projectPath: string, nodeId: string): RenderedNode | nu
   return extractRenderedNode(text, nodeId);
 }
 
+// Canonical chapter order is the order of `\input{chapters/X}` lines in
+// blueprint/src/content.tex. Cached with mtime invalidation since this file
+// rarely changes. Falls back to filename glob (alphabetical) if content.tex
+// is missing or has no `\input` lines.
+let chapterOrderCache: { base: string; mtime: number; order: string[] } | null = null;
+
+function getChapterOrder(projectPath: string): string[] {
+  const contentTex = path.join(projectPath, 'blueprint', 'src', 'content.tex');
+  let mtime = 0;
+  try { mtime = fs.statSync(contentTex).mtimeMs; } catch { /* not present */ }
+
+  if (chapterOrderCache && chapterOrderCache.base === contentTex && chapterOrderCache.mtime === mtime) {
+    return chapterOrderCache.order;
+  }
+
+  let order: string[] = [];
+  if (mtime > 0) {
+    try {
+      const text = fs.readFileSync(contentTex, 'utf-8');
+      const re = /\\input\s*\{\s*chapters\/([A-Za-z0-9_-]+)\s*\}/g;
+      const seen = new Set<string>();
+      let m: RegExpExecArray | null;
+      while ((m = re.exec(text)) !== null) {
+        if (!seen.has(m[1])) { seen.add(m[1]); order.push(m[1]); }
+      }
+    } catch { /* ignore, fall back below */ }
+  }
+
+  if (order.length === 0) {
+    // Fallback: sorted filenames in chapters/ — stable but alphabetical.
+    const dir = path.join(projectPath, 'blueprint', 'src', 'chapters');
+    try {
+      order = fs.readdirSync(dir)
+        .filter(f => f.endsWith('.tex'))
+        .map(f => f.replace(/\.tex$/, ''))
+        .sort();
+    } catch { /* leave empty */ }
+  }
+
+  chapterOrderCache = { base: contentTex, mtime, order };
+  return order;
+}
+
 function openDb(projectPath: string): Database.Database | null {
   const candidate = path.join(projectPath, '.kip', 'state.db');
   if (!fs.existsSync(candidate)) return null;
@@ -233,13 +275,12 @@ export function register(fastify: FastifyInstance, paths: ProjectPaths) {
     const db = openDb(projectPath);
     if (!db) return [];
     const rows = db.prepare(
-      "SELECT from_node, to_node, source, confirmed FROM edges"
+      "SELECT from_node, to_node, source FROM edges"
     ).all() as EdgeRow[];
     return rows.map(r => ({
       from: r.from_node,
       to: r.to_node,
       source: r.source,
-      confirmed: !!r.confirmed,
     }));
   });
 
@@ -257,8 +298,8 @@ export function register(fastify: FastifyInstance, paths: ProjectPaths) {
       }
       const nodes = db.prepare("SELECT id, kind, chapter, phase FROM nodes").all() as
         { id: string; kind: string | null; chapter: string | null; phase: string }[];
-      const edges = db.prepare("SELECT from_node, to_node, confirmed FROM edges").all() as
-        { from_node: string; to_node: string; confirmed: number }[];
+      const edges = db.prepare("SELECT from_node, to_node FROM edges").all() as
+        { from_node: string; to_node: string }[];
 
       const filters: GraphFilters = {};
       if (req.query.phases) filters.phases = new Set(req.query.phases.split(',').filter(Boolean));
@@ -281,11 +322,20 @@ export function register(fastify: FastifyInstance, paths: ProjectPaths) {
   // Combined payload sized for one round-trip into the DAG view.
   fastify.get('/api/graph', async () => {
     const db = openDb(projectPath);
-    if (!db) return { nodes: [], edges: [] };
+    if (!db) return { nodes: [], edges: [], chapters: [] };
     const nodes = (db.prepare("SELECT * FROM nodes ORDER BY id").all() as NodeRow[]).map(shapeNode);
-    const edges = (db.prepare("SELECT from_node, to_node, source, confirmed FROM edges").all() as EdgeRow[])
-      .map(r => ({ from: r.from_node, to: r.to_node, source: r.source, confirmed: !!r.confirmed }));
-    return { nodes, edges };
+    const edges = (db.prepare("SELECT from_node, to_node, source FROM edges").all() as EdgeRow[])
+      .map(r => ({ from: r.from_node, to: r.to_node, source: r.source }));
+    // Chapters in the order they appear in blueprint/src/content.tex,
+    // restricted to chapters that contain at least one node so the sidebar
+    // doesn't list empty buckets.
+    const present = new Set<string>();
+    for (const n of nodes) if (n.chapter) present.add(n.chapter);
+    const chapters = getChapterOrder(projectPath).filter(c => present.has(c));
+    // Append any chapters that have nodes but aren't listed in content.tex,
+    // so we never silently drop a populated bucket.
+    for (const c of present) if (!chapters.includes(c)) chapters.push(c);
+    return { nodes, edges, chapters };
   });
 
   fastify.get<{ Params: { id: string } }>('/api/nodes/:id', async (req, reply) => {
@@ -300,12 +350,12 @@ export function register(fastify: FastifyInstance, paths: ProjectPaths) {
     ).all(id);
 
     const usesEdges = db.prepare(
-      "SELECT to_node, confirmed FROM edges WHERE from_node = ? ORDER BY to_node"
-    ).all(id) as { to_node: string; confirmed: number }[];
+      "SELECT to_node FROM edges WHERE from_node = ? ORDER BY to_node"
+    ).all(id) as { to_node: string }[];
 
     const usedByEdges = db.prepare(
-      "SELECT from_node, confirmed FROM edges WHERE to_node = ? ORDER BY from_node"
-    ).all(id) as { from_node: string; confirmed: number }[];
+      "SELECT from_node FROM edges WHERE to_node = ? ORDER BY from_node"
+    ).all(id) as { from_node: string }[];
 
     const leanDecl = row.lean_decl
       ? db.prepare("SELECT * FROM lean_decls WHERE name = ?").get(row.lean_decl)
@@ -357,8 +407,8 @@ export function register(fastify: FastifyInstance, paths: ProjectPaths) {
     return {
       ...shapeNode(row),
       comments,
-      uses: usesEdges.map(e => ({ id: e.to_node, confirmed: !!e.confirmed })),
-      usedBy: usedByEdges.map(e => ({ id: e.from_node, confirmed: !!e.confirmed })),
+      uses: usesEdges.map(e => ({ id: e.to_node })),
+      usedBy: usedByEdges.map(e => ({ id: e.from_node })),
       leanDecl,
       runs,
       nlExcerpt,

--- a/ui/server/src/routes/nodes.ts
+++ b/ui/server/src/routes/nodes.ts
@@ -1,9 +1,10 @@
 import fs from 'fs';
 import path from 'path';
 import Database from 'better-sqlite3';
+import yaml from 'js-yaml';
 import type { FastifyInstance } from 'fastify';
 import type { ProjectPaths } from '../index.js';
-import { buildDot, renderSvg, type GraphFilters } from './graph_svg.js';
+import { buildDot, renderSvg, BLUEPRINT_KINDS, type GraphFilters } from './graph_svg.js';
 
 interface NodeRow {
   id: string;
@@ -209,6 +210,96 @@ function openDb(projectPath: string): Database.Database | null {
   return dbInstance;
 }
 
+// Separate write handle, used only by review actions. Each call opens / closes
+// to avoid juggling cache invalidation alongside the readonly handle above.
+function openDbForWrite(projectPath: string): Database.Database | null {
+  const candidate = path.join(projectPath, '.kip', 'state.db');
+  if (!fs.existsSync(candidate)) return null;
+  return new Database(candidate, { readonly: false, fileMustExist: true });
+}
+
+// ---------- status.yaml read/write -------------------------------------------
+
+interface StatusComment {
+  topic?: string;
+  text?: string;
+  by?: string;
+  at?: string;
+  [key: string]: unknown;
+}
+
+interface StatusEntry {
+  lean_decl?: string;
+  nl_reviewed?: boolean;
+  bound?: boolean;
+  aligned?: boolean;
+  proved?: boolean;
+  kind?: string;
+  comments?: StatusComment[];
+  nl_reviewer?: string;
+  nl_reviewed_at?: string;
+  align_reviewer?: string;
+  aligned_at?: string;
+  nl_hash?: string;
+  [key: string]: unknown;
+}
+
+interface StatusFile {
+  nodes?: Record<string, StatusEntry>;
+  [key: string]: unknown;
+}
+
+function loadStatus(yamlPath: string): StatusFile {
+  if (!fs.existsSync(yamlPath)) return { nodes: {} };
+  const text = fs.readFileSync(yamlPath, 'utf-8');
+  const data = yaml.load(text);
+  if (!data || typeof data !== 'object') return { nodes: {} };
+  return data as StatusFile;
+}
+
+function saveStatus(yamlPath: string, data: StatusFile): void {
+  // Match existing style: dates as quoted strings (yaml.dump quotes any
+  // string scalar with quotingType "'" — fine since flags/booleans dump
+  // unquoted). lineWidth: -1 disables auto-wrap so long IDs/strings stay
+  // on one line.
+  const out = yaml.dump(data, {
+    lineWidth: -1,
+    noRefs: true,
+    sortKeys: false,
+    quotingType: "'",
+    forceQuotes: false,
+  });
+  const tmp = yamlPath + '.tmp';
+  fs.writeFileSync(tmp, out, 'utf-8');
+  // Best-effort fsync before rename so a crash mid-write can't leave a
+  // half-written status.yaml.
+  try {
+    const fd = fs.openSync(tmp, 'r');
+    fs.fsyncSync(fd);
+    fs.closeSync(fd);
+  } catch { /* ignore */ }
+  fs.renameSync(tmp, yamlPath);
+}
+
+// Mirror tools/kip-state/index.py:derive_phase. Keep in sync with that file.
+function derivePhase(flags: {
+  nl_reviewed?: boolean; bound?: boolean; aligned?: boolean; proved?: boolean;
+}): 'drafted' | 'nl_reviewed' | 'bound' | 'aligned' | 'proved' {
+  if (flags.proved) return 'proved';
+  if (flags.aligned) return 'aligned';
+  if (flags.bound) return 'bound';
+  if (flags.nl_reviewed) return 'nl_reviewed';
+  return 'drafted';
+}
+
+function nowIso(): string {
+  // Full ISO-8601 instant with UTC marker (e.g. 2026-04-27T08:15:32.123Z).
+  // The client renders this in Beijing time and computes relative diffs from
+  // it directly — date-only strings like '2026-04-19' (the legacy yaml form)
+  // would be off by up to 8h after parsing as UTC midnight.
+  return new Date().toISOString();
+}
+
 function shapeNode(r: NodeRow) {
   return {
     id: r.id,
@@ -296,10 +387,13 @@ export function register(fastify: FastifyInstance, paths: ProjectPaths) {
         reply.status(503);
         return { error: 'state.db not built' };
       }
-      const nodes = db.prepare("SELECT id, kind, chapter, phase FROM nodes").all() as
+      const allNodes = db.prepare("SELECT id, kind, chapter, phase FROM nodes").all() as
         { id: string; kind: string | null; chapter: string | null; phase: string }[];
-      const edges = db.prepare("SELECT from_node, to_node FROM edges").all() as
-        { from_node: string; to_node: string }[];
+      const nodes = allNodes.filter(n => !n.kind || BLUEPRINT_KINDS.has(n.kind));
+      const visibleIds = new Set(nodes.map(n => n.id));
+      const edges = (db.prepare("SELECT from_node, to_node FROM edges").all() as
+        { from_node: string; to_node: string }[])
+        .filter(e => visibleIds.has(e.from_node) && visibleIds.has(e.to_node));
 
       const filters: GraphFilters = {};
       if (req.query.phases) filters.phases = new Set(req.query.phases.split(',').filter(Boolean));
@@ -323,8 +417,16 @@ export function register(fastify: FastifyInstance, paths: ProjectPaths) {
   fastify.get('/api/graph', async () => {
     const db = openDb(projectPath);
     if (!db) return { nodes: [], edges: [], chapters: [] };
-    const nodes = (db.prepare("SELECT * FROM nodes ORDER BY id").all() as NodeRow[]).map(shapeNode);
+    // Restrict to blueprint kinds — remarks/examples/questions are commentary
+    // and don't belong on the dependency DAG or sidebar counts. Detail
+    // endpoints (/api/nodes/:id) still serve them so deep links keep working.
+    const allRows = db.prepare("SELECT * FROM nodes ORDER BY id").all() as NodeRow[];
+    const nodes = allRows
+      .filter(r => !r.kind || BLUEPRINT_KINDS.has(r.kind))
+      .map(shapeNode);
+    const visibleIds = new Set(nodes.map(n => n.id));
     const edges = (db.prepare("SELECT from_node, to_node, source FROM edges").all() as EdgeRow[])
+      .filter(r => visibleIds.has(r.from_node) && visibleIds.has(r.to_node))
       .map(r => ({ from: r.from_node, to: r.to_node, source: r.source }));
     // Chapters in the order they appear in blueprint/src/content.tex,
     // restricted to chapters that contain at least one node so the sidebar
@@ -414,5 +516,124 @@ export function register(fastify: FastifyInstance, paths: ProjectPaths) {
       nlExcerpt,
       nlRendered,
     };
+  });
+
+  // Human review actions. Two kinds, both move the node forward in the
+  // lifecycle and leave a comment trail:
+  //   approve_nl         drafted          → nl_reviewed
+  //   confirm_alignment  nl_reviewed+bound → aligned
+  // Source of truth is blueprint/status.yaml (what tools/kip-state/index.py
+  // reads on rebuild). We mirror the change into .kip/state.db so the dashboard
+  // reflects it immediately without re-running the indexer.
+  fastify.post<{
+    Params: { id: string };
+    Body: { action?: string; reviewer?: string; comment?: string };
+  }>('/api/nodes/:id/review', async (req, reply) => {
+    const id = req.params.id;
+    const action = (req.body?.action || '').trim();
+    const reviewer = (req.body?.reviewer || '').trim();
+    const userComment = (req.body?.comment || '').trim();
+
+    if (action !== 'approve_nl' && action !== 'confirm_alignment') {
+      return reply.status(400).send({ error: 'action must be approve_nl or confirm_alignment' });
+    }
+    if (!reviewer) {
+      return reply.status(400).send({ error: 'reviewer is required' });
+    }
+
+    const db = openDb(projectPath);
+    if (!db) return reply.status(503).send({ error: 'state.db not built' });
+    const row = db.prepare("SELECT * FROM nodes WHERE id = ?").get(id) as NodeRow | undefined;
+    if (!row) return reply.status(404).send({ error: 'Node not found' });
+
+    const flags = {
+      nl_reviewed: !!row.nl_reviewed,
+      bound: !!row.bound,
+      aligned: !!row.aligned,
+      proved: !!row.proved,
+    };
+
+    if (action === 'approve_nl') {
+      if (flags.nl_reviewed) {
+        return reply.status(409).send({ error: 'NL already reviewed' });
+      }
+    } else { // confirm_alignment
+      if (!flags.nl_reviewed) {
+        return reply.status(409).send({ error: 'NL not yet reviewed' });
+      }
+      if (!flags.bound) {
+        return reply.status(409).send({ error: 'Lean declaration not bound yet' });
+      }
+      if (flags.aligned) {
+        return reply.status(409).send({ error: 'already aligned' });
+      }
+    }
+
+    const now = nowIso();
+    const yamlPath = path.join(projectPath, 'blueprint', 'status.yaml');
+    const status = loadStatus(yamlPath);
+    if (!status.nodes) status.nodes = {};
+    const entry: StatusEntry = status.nodes[id] || {};
+
+    const commentTopic = action === 'approve_nl' ? 'nl-review' : 'align';
+    const defaultText = action === 'approve_nl' ? 'NL approved' : 'Alignment confirmed';
+    const newComment: StatusComment = {
+      topic: commentTopic,
+      text: userComment || defaultText,
+      by: reviewer,
+      at: now,
+    };
+    const existingComments = Array.isArray(entry.comments) ? entry.comments : [];
+    entry.comments = [...existingComments, newComment];
+
+    if (action === 'approve_nl') {
+      entry.nl_reviewed = true;
+      entry.nl_reviewer = reviewer;
+      entry.nl_reviewed_at = now;
+    } else {
+      entry.aligned = true;
+      entry.align_reviewer = reviewer;
+      entry.aligned_at = now;
+    }
+    status.nodes[id] = entry;
+
+    // Mirror to DB cache. Wrap in a transaction so a crash midway leaves the DB
+    // either fully updated or untouched (yaml is already saved at this point —
+    // worst case the next index.py run re-derives from yaml and reconciles).
+    saveStatus(yamlPath, status);
+
+    const writeDb = openDbForWrite(projectPath);
+    if (writeDb) {
+      try {
+        const newFlags = {
+          ...flags,
+          nl_reviewed: action === 'approve_nl' ? true : flags.nl_reviewed,
+          aligned: action === 'confirm_alignment' ? true : flags.aligned,
+        };
+        const newPhase = derivePhase(newFlags);
+        const tx = writeDb.transaction(() => {
+          if (action === 'approve_nl') {
+            writeDb.prepare(
+              "UPDATE nodes SET nl_reviewed=1, nl_reviewer=?, last_activity=?, phase=? WHERE id=?"
+            ).run(reviewer, now, newPhase, id);
+          } else {
+            writeDb.prepare(
+              "UPDATE nodes SET aligned=1, align_reviewer=?, aligned_at=?, last_activity=?, phase=? WHERE id=?"
+            ).run(reviewer, now, now, newPhase, id);
+          }
+          const maxIdx = writeDb.prepare(
+            "SELECT COALESCE(MAX(idx), -1) AS m FROM node_comments WHERE node_id=?"
+          ).get(id) as { m: number };
+          writeDb.prepare(
+            "INSERT INTO node_comments(node_id, idx, topic, text, by, at) VALUES (?,?,?,?,?,?)"
+          ).run(id, maxIdx.m + 1, commentTopic, newComment.text, reviewer, now);
+        });
+        tx();
+      } finally {
+        try { writeDb.close(); } catch { /* ignore */ }
+      }
+    }
+
+    return { ok: true, id, action, reviewer, at: now };
   });
 }

--- a/ui/server/src/routes/nodes.ts
+++ b/ui/server/src/routes/nodes.ts
@@ -10,6 +10,7 @@ interface NodeRow {
   id: string;
   kind: string | null;
   chapter: string | null;
+  subsection: string | null;
   source_file: string | null;
   source_line: number | null;
   lean_decl: string | null;
@@ -305,6 +306,7 @@ function shapeNode(r: NodeRow) {
     id: r.id,
     kind: r.kind,
     chapter: r.chapter,
+    subsection: r.subsection,
     sourceFile: r.source_file,
     sourceLine: r.source_line,
     leanDecl: r.lean_decl,
@@ -387,8 +389,10 @@ export function register(fastify: FastifyInstance, paths: ProjectPaths) {
         reply.status(503);
         return { error: 'state.db not built' };
       }
-      const allNodes = db.prepare("SELECT id, kind, chapter, phase FROM nodes").all() as
-        { id: string; kind: string | null; chapter: string | null; phase: string }[];
+      const allNodes = db.prepare(
+        "SELECT id, kind, chapter, subsection, phase FROM nodes"
+      ).all() as
+        { id: string; kind: string | null; chapter: string | null; subsection: string | null; phase: string }[];
       const nodes = allNodes.filter(n => !n.kind || BLUEPRINT_KINDS.has(n.kind));
       const visibleIds = new Set(nodes.map(n => n.id));
       const edges = (db.prepare("SELECT from_node, to_node FROM edges").all() as


### PR DESCRIPTION
Closes AUT-41.

Reorients the KIP agent dashboard around the **dependency-graph node** as the central entity, replacing the agent-run-centric Overview as the default tab.

## Summary

- **`tools/kip-state/`** — SQLite indexer (`.kip/state.db`, gitignored) derived from `blueprint/status.yaml` + chapter LaTeX (`\uses{}`, `\lean{}`, `\leanok`) + Lean source (declarations + `sorry` counts) + agent logs. Truth stays in source; the DB is a rebuildable cache. Run with `python tools/kip-state/index.py`.
- **`ui/server`** — new routes `/api/state/health`, `/api/nodes`, `/api/edges`, `/api/graph`, `/api/nodes/:id` reading via `better-sqlite3`. Node-detail extracts pre-rendered LaTeX blocks (caption + label + thmcontent) from `blueprint/web/sec-*.html`, falling back to raw `.tex` excerpt when blueprint web hasn't been built.
- **`ui/client`** — Cytoscape DAG (`react-cytoscapejs` + `cytoscape-dagre`) as the new default tab. Color = lifecycle phase, shape = kind, click → side drawer with rendered NL (MathJax-typeset, identical look to blueprint web), Lean decl info, uses/usedBy, comments, agent runs touching the node. Old Overview rewritten to phase histogram + 14-day stale backlog. Logs tab unchanged.

## Lifecycle phases

5 axes matching `status.yaml` flags: `drafted | nl_reviewed | bound | aligned | proved`. (Edges-confirmation is treated as part of `nl_reviewed` per the existing YAML semantics.)

## Test plan

- [x] `python tools/kip-state/index.py` → `239 nodes · 321 edges · 299 lean decls · 7 agent runs`
- [x] `cd ui/client && npm run build` clean (no TS errors)
- [x] `./ui/start.sh` boots; clicked through DAG, drawer, filters (phase / chapter / search), deep links, /overview, /logs
- [x] Node drawer shows MathJax-rendered NL (e.g. `prereq:def:ss-data` → "Definition 0.1" with rendered enumerate + `\(\mathcal{C}\)`)
- [x] Edges visually unselectable (`cy.edges().unselectify()`)
- [ ] Reviewer: rebuild blueprint web (`cd blueprint && ./build.sh`) and confirm rendered NL appears for new nodes

## Out of scope (next round)

- Write-back: marking `aligned` from UI → patches YAML → opens PR
- Triggering agents (absorber/prover/...) from a node row
- Logs tab `node-id` filter chip

🤖 Generated with [Claude Code](https://claude.com/claude-code)
