### PR TITLE
feat(deploy): Docker 化 KIP dashboard，实现开机自启

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+# Stage 1: Build blueprint web output (Alpine + TeXLive)
+FROM ghcr.io/xu-cheng/texlive-full:20250401 AS builder
+
+RUN apk update && apk add --update make py3-pip git pkgconfig graphviz graphviz-dev gcc musl-dev
+
+WORKDIR /app
+
+COPY tools/ tools/
+COPY blueprint/ blueprint/
+COPY lakefile.toml lean-toolchain lake-manifest.json ./
+
+RUN git init && git config --global --add safe.directory /app
+
+RUN python3 -m venv /env && . /env/bin/activate \
+    && pip install --upgrade pip requests wheel \
+    && pip install pygraphviz \
+        --config-settings="--global-option=build_ext" \
+        --config-settings="--global-option=-L/usr/lib/graphviz/" \
+        --config-settings="--global-option=-R/usr/lib/graphviz/" \
+    && pip install -e ./tools/plastexdepgraph \
+    && pip install -e ./tools/leanblueprint
+
+RUN . /env/bin/activate && cd blueprint && leanblueprint web
+
+# Stage 2: Lightweight runtime (Debian)
+FROM python:3.12-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git graphviz libgraphviz-dev gcc pkg-config libc6-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY tools/ tools/
+COPY lakefile.toml lean-toolchain lake-manifest.json ./
+COPY --from=builder /app/blueprint blueprint/
+
+RUN pip install --no-cache-dir pygraphviz \
+    && pip install --no-cache-dir -e ./tools/plastexdepgraph \
+    && pip install --no-cache-dir -e ./tools/leanblueprint
+
+RUN git init && git config --global --add safe.directory /app
+
+EXPOSE 8000
+
+CMD ["leanblueprint", "serve"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: kip-server
+    ports:
+      - "8082:8000"
+    volumes:
+      - ./blueprint/status.yaml:/app/blueprint/status.yaml
+    restart: unless-stopped
+
+  dashboard:
+    build:
+      context: .
+      dockerfile: ui/Dockerfile
+    container_name: kip-dashboard
+    ports:
+      - "18080:8081"
+    volumes:
+      - .:/project
+    restart: unless-stopped

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,0 +1,38 @@
+# Stage 1: Build client
+FROM node:22-slim AS client-builder
+WORKDIR /build
+COPY ui/client/package*.json ./
+RUN npm ci
+COPY ui/client/ ./
+RUN npm run build
+
+# Stage 2: Build server
+FROM node:22-slim AS server-builder
+WORKDIR /build
+COPY ui/server/package*.json ./
+RUN npm ci
+COPY ui/server/ ./
+RUN npm run build
+
+# Stage 3: Runtime
+FROM node:22-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    graphviz \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Production server deps (includes native better-sqlite3, compiled for this image)
+COPY ui/server/package*.json ./server/
+RUN cd server && npm ci --omit=dev
+
+# Compiled server JS
+COPY --from=server-builder /build/dist ./server/dist
+
+# Built client — must be at /app/client/dist so that
+# server/dist/index.js's `../../client/dist` resolves correctly
+COPY --from=client-builder /build/dist ./client/dist
+
+EXPOSE 8081
+
+CMD ["node", "server/dist/index.js", "--project", "/project", "--port", "8081"]


### PR DESCRIPTION
## 完成了什么

将 KIP dashboard（`ui/`）容器化，使其和现有的 `kip-server`（leanblueprint serve）一样，通过 docker-compose 管理，服务器重启后自动拉起，不再依赖手动启动命令。

### 新增文件

**`ui/Dockerfile`** — dashboard 的三阶段构建：
1. `client-builder`：用 Vite 构建 React 前端，输出 `dist/`
2. `server-builder`：用 `tsc` 编译 Fastify 后端，输出 `dist/`
3. 运行时镜像：`node:22-slim` + Graphviz（DAG 渲染必需），体积最小

**`docker-compose.yml`** — 定义两个服务：
- `kip-server`：原有的 leanblueprint serve（端口 8082），`restart: unless-stopped`
- `dashboard`：新增 dashboard 服务（端口 18080），挂载项目根目录为 `/project`，`restart: unless-stopped`

**`Dockerfile`** — 恢复 leanblueprint serve 的构建文件（原本只在 `feat/unify-annotation-system` 分支上，main 分支缺失）

### 部署效果

- `kip.opensii.ai/dashboard/` 现已通过 docker-compose 稳定运行
- 服务器重启后 dashboard 自动恢复，无需人工干预
- 进程崩溃后 Docker 自动重启

### 本地验证

```bash
docker compose up -d dashboard
curl http://localhost:18080/api/state/health
# → {"ok":true,"counts":{"nodes":239,"edges":321,...}}
```

## 背景

关联 issue：#18（跨主机日志上报）、#19（分布式 agent 调度）