### PR TITLE
feat: 跨主机 agent 日志实时上报 (issue #18)

### DIFF
--- a/agents/blueprint-absorber/README.md
+++ b/agents/blueprint-absorber/README.md
@@ -1,0 +1,54 @@
+# Blueprint Absorber Agent
+
+将 `draft-hint/` 里的数学家提示文件吸收进 `blueprint/src/chapters/*.tex`。
+
+## 前置条件
+
+```bash
+pip install -e tools/plastexdepgraph
+pip install -e tools/leanblueprint
+```
+
+## 本地运行
+
+```bash
+# 处理单个文件
+./agents/blueprint-absorber/run.sh draft-hint/foo.md
+
+# 处理所有待吸收文件
+./agents/blueprint-absorber/run.sh
+
+# 指定模型
+./agents/blueprint-absorber/run.sh --model opus draft-hint/foo.md
+
+# 试运行（只显示会处理哪些文件，不实际调用 claude）
+./agents/blueprint-absorber/run.sh --dry-run
+```
+
+运行日志保存在 `agents/blueprint-absorber/logs/run-<timestamp>/absorber.jsonl`。
+
+## 远程监控（多机协作）
+
+如果需要在本机跑 agent、同时让部署在服务器上的 dashboard 实时看到运行进度，
+设置以下两个环境变量即可：
+
+```bash
+export KIP_INGEST_URL=https://kip.opensii.ai/dashboard/api/ingest
+export KIP_INGEST_TOKEN=<token>   # 与服务器 KIP_INGEST_TOKEN 一致，未配置 token 时可不设
+```
+
+设置后正常跑 agent，每条日志 event 会自动上报到服务器，在 dashboard 的
+**Logs** tab 实时可见。未设置 `KIP_INGEST_URL` 时行为与纯本地模式完全一致。
+
+### 验证网络是否通
+
+```bash
+curl -s -w "\nHTTP %{http_code}" -X POST "$KIP_INGEST_URL" -H "Content-Type: application/json" -d '{"agent":"blueprint-absorber","runId":"run-test","hintFile":"test","row":{"ts":"2026-01-01T00:00:00Z","event":"text","content":"ping"}}'
+```
+
+返回 `HTTP 204` 即表示连接正常。
+
+## 状态追踪
+
+`agents/blueprint-absorber/STATUS.md` 记录哪些 hint 文件已吸收（Absorbed）、哪些待处理（Pending）。
+成功吸收后 agent 自动更新此文件。

--- a/agents/blueprint-absorber/run.sh
+++ b/agents/blueprint-absorber/run.sh
@@ -124,16 +124,35 @@ Instructions:
    - If the file was listed under '## Pending', remove it from there.
 8. Report what changed and whether validation passed." \
         2>>"$stderr_dest" | python3 -u -c "
-import sys, json, datetime
+import sys, json, datetime, urllib.request, os
 
 VERBOSE = '$VERBOSE_LOGS' == 'true'
 RAW = open('$RAW_FILE', 'a') if VERBOSE else None
 JSONL = open('$JSONL_FILE', 'a')
 
+_INGEST_URL   = os.getenv('KIP_INGEST_URL', '')
+_INGEST_TOKEN = os.getenv('KIP_INGEST_TOKEN', '')
+_AGENT        = 'blueprint-absorber'
+_RUN_ID       = 'run-$RUN_TS'
+_HINT_FILE    = '$HINT_FILE'
+
+def ingest(row):
+    if not _INGEST_URL:
+        return
+    payload = json.dumps({'agent': _AGENT, 'runId': _RUN_ID, 'hintFile': _HINT_FILE, 'row': row}).encode()
+    req = urllib.request.Request(_INGEST_URL, data=payload,
+        headers={'Content-Type': 'application/json', 'Authorization': 'Bearer ' + _INGEST_TOKEN},
+        method='POST')
+    try:
+        urllib.request.urlopen(req, timeout=3)
+    except Exception:
+        pass
+
 def emit(event_type, **fields):
     row = {'ts': datetime.datetime.now(datetime.timezone.utc).isoformat().replace('+00:00', 'Z'), 'event': event_type, **fields}
     JSONL.write(json.dumps(row) + '\n')
     JSONL.flush()
+    ingest(row)
 
 last_result = ''
 

--- a/ui/server/src/index.ts
+++ b/ui/server/src/index.ts
@@ -11,6 +11,7 @@ import { register as registerAgents } from './routes/agents.js';
 import { register as registerLogs } from './routes/logs.js';
 import { register as registerSummary } from './routes/summary.js';
 import { register as registerNodes } from './routes/nodes.js';
+import { register as registerIngest } from './routes/ingest.js';
 
 export interface ProjectPaths {
   projectPath: string;
@@ -64,6 +65,7 @@ export async function createServer(options: { projectPath: string; port: number 
   registerLogs(fastify, paths);
   registerSummary(fastify, paths);
   registerNodes(fastify, paths);
+  registerIngest(fastify, paths);
 
   await fastify.listen({ port, host: '0.0.0.0' });
   return fastify;

--- a/ui/server/src/routes/ingest.ts
+++ b/ui/server/src/routes/ingest.ts
@@ -19,7 +19,10 @@ export function register(fastify: FastifyInstance, paths: ProjectPaths) {
       }
     }
 
-    const { agent, runId, hintFile, row } = req.body as Record<string, unknown>;
+    const body = req.body as Record<string, unknown> | undefined;
+    if (!body) return reply.code(400).send({ error: 'missing JSON body' });
+
+    const { agent, runId, hintFile, row } = body;
 
     if (!safeSeg(agent) || !safeSeg(runId)) {
       return reply.code(400).send({ error: 'invalid agent or runId' });

--- a/ui/server/src/routes/ingest.ts
+++ b/ui/server/src/routes/ingest.ts
@@ -1,0 +1,72 @@
+import fs from 'fs';
+import path from 'path';
+import type { FastifyInstance } from 'fastify';
+import type { ProjectPaths } from '../index.js';
+
+const TOKEN = process.env.KIP_INGEST_TOKEN ?? '';
+
+// agent name and runId must be safe path segments
+function safeSeg(s: unknown): s is string {
+  return typeof s === 'string' && /^[\w.\-:]+$/.test(s) && !s.includes('..');
+}
+
+export function register(fastify: FastifyInstance, paths: ProjectPaths) {
+  fastify.post('/api/ingest', async (req, reply) => {
+    if (TOKEN) {
+      const auth = (req.headers.authorization ?? '') as string;
+      if (auth !== `Bearer ${TOKEN}`) {
+        return reply.code(401).send({ error: 'unauthorized' });
+      }
+    }
+
+    const { agent, runId, hintFile, row } = req.body as Record<string, unknown>;
+
+    if (!safeSeg(agent) || !safeSeg(runId)) {
+      return reply.code(400).send({ error: 'invalid agent or runId' });
+    }
+
+    const runDir = path.resolve(paths.agentsPath, agent, 'logs', runId);
+    if (!runDir.startsWith(paths.agentsPath + path.sep)) {
+      return reply.code(400).send({ error: 'path outside agents directory' });
+    }
+
+    fs.mkdirSync(runDir, { recursive: true });
+
+    const metaFile = path.join(runDir, 'meta.json');
+    const jsonlFile = path.join(runDir, 'absorber.jsonl');
+
+    // Write meta.json on the first event for this run
+    if (!fs.existsSync(metaFile)) {
+      const meta = {
+        agent,
+        hint_file: typeof hintFile === 'string' ? hintFile : null,
+        startedAt: (row as Record<string, unknown>)?.ts ?? new Date().toISOString(),
+        completedAt: null,
+        status: 'running',
+        model: null,
+      };
+      fs.writeFileSync(metaFile, JSON.stringify(meta, null, 2));
+    }
+
+    // Update meta on session_end
+    if ((row as Record<string, unknown>)?.event === 'session_end') {
+      try {
+        const meta = JSON.parse(fs.readFileSync(metaFile, 'utf-8'));
+        meta.completedAt = (row as Record<string, unknown>).ts ?? new Date().toISOString();
+        meta.status = 'done';
+        const usage = (row as Record<string, unknown>).model_usage as Record<string, unknown> | undefined;
+        if (usage) {
+          const first = Object.keys(usage)[0];
+          if (first) meta.model = first;
+        }
+        fs.writeFileSync(metaFile, JSON.stringify(meta, null, 2));
+      } catch { /* ignore */ }
+    }
+
+    // Append event row to JSONL — fs.watch in logs.ts picks this up automatically
+    // and broadcasts to any connected WebSocket clients watching this file
+    fs.appendFileSync(jsonlFile, JSON.stringify(row) + '\n');
+
+    return reply.code(204).send();
+  });
+}


### PR DESCRIPTION
关联 issue：#18

## 完成了什么

让不同机器上跑的 agent，日志能实时汇聚到部署在服务器上的 dashboard，不需要登录工作机也能监控运行进度。

### 改动说明

**`ui/server/src/routes/ingest.ts`**（新文件）

新增 `POST /api/ingest` 端点：
- 可选 Bearer token 鉴权（服务器设置 `KIP_INGEST_TOKEN` 环境变量）
- 校验 agent/runId 为安全路径段，防止路径穿越
- 第一条 event 到达时自动创建 `agents/<agent>/logs/<runId>/` 目录和 `meta.json`
- `session_end` event 时更新 meta.json 的 `completedAt` 和 `status`
- 将 event 追加写入 `absorber.jsonl`
- 无需额外 WebSocket 代码——`logs.ts` 里已有的 `fs.watch` 检测到新字节后会自动推送给前端

**`agents/blueprint-absorber/run.sh`**

在 Python 内联日志解析脚本的 `emit()` 函数末尾加了 `ingest(row)` 调用：
- 读取 `KIP_INGEST_URL` / `KIP_INGEST_TOKEN` 环境变量
- 未设置 `KIP_INGEST_URL` 时为 no-op，本地模式完全不受影响
- 3秒超时，失败静默忽略，不阻塞 agent 运行

### 工作机使用方式

```bash
# 在工作机的 ~/.bashrc 或运行前设置
export KIP_INGEST_URL=https://kip.opensii.ai/dashboard/api/ingest
export KIP_INGEST_TOKEN=<token>   # 与服务器 KIP_INGEST_TOKEN 一致

# 正常跑 agent，日志自动上报
./agents/blueprint-absorber/run.sh draft-hint/foo.md
```

### 验证

```bash
# 模拟工作机上报一条 event
curl -X POST https://kip.opensii.ai/dashboard/api/ingest \
  -H "Content-Type: application/json" \
  -d '{"agent":"blueprint-absorber","runId":"run-2026-04-30T10-00-00Z",
       "hintFile":"draft-hint/test.md",
       "row":{"ts":"2026-04-30T10:00:00Z","event":"text","content":"hello"}}'
# → HTTP 204，宿主机 agents/blueprint-absorber/logs/run-.../absorber.jsonl 有内容
# → dashboard /logs 页面实时显示该条记录
```