### PR TITLE
feat(homepage): 恢复首页并加入 dashboard 入口和实时进度条

### DIFF
--- a/agents/blueprint-absorber/README.md
+++ b/agents/blueprint-absorber/README.md
@@ -1,0 +1,54 @@
+# Blueprint Absorber Agent
+
+将 `draft-hint/` 里的数学家提示文件吸收进 `blueprint/src/chapters/*.tex`。
+
+## 前置条件
+
+```bash
+pip install -e tools/plastexdepgraph
+pip install -e tools/leanblueprint
+```
+
+## 本地运行
+
+```bash
+# 处理单个文件
+./agents/blueprint-absorber/run.sh draft-hint/foo.md
+
+# 处理所有待吸收文件
+./agents/blueprint-absorber/run.sh
+
+# 指定模型
+./agents/blueprint-absorber/run.sh --model opus draft-hint/foo.md
+
+# 试运行（只显示会处理哪些文件，不实际调用 claude）
+./agents/blueprint-absorber/run.sh --dry-run
+```
+
+运行日志保存在 `agents/blueprint-absorber/logs/run-<timestamp>/absorber.jsonl`。
+
+## 远程监控（多机协作）
+
+如果需要在本机跑 agent、同时让部署在服务器上的 dashboard 实时看到运行进度，
+设置以下两个环境变量即可：
+
+```bash
+export KIP_INGEST_URL=https://kip.opensii.ai/dashboard/api/ingest
+export KIP_INGEST_TOKEN=<token>   # 与服务器 KIP_INGEST_TOKEN 一致，未配置 token 时可不设
+```
+
+设置后正常跑 agent，每条日志 event 会自动上报到服务器，在 dashboard 的
+**Logs** tab 实时可见。未设置 `KIP_INGEST_URL` 时行为与纯本地模式完全一致。
+
+### 验证网络是否通
+
+```bash
+curl -s -w "\nHTTP %{http_code}" -X POST "$KIP_INGEST_URL" -H "Content-Type: application/json" -d '{"agent":"blueprint-absorber","runId":"run-test","hintFile":"test","row":{"ts":"2026-01-01T00:00:00Z","event":"text","content":"ping"}}'
+```
+
+返回 `HTTP 204` 即表示连接正常。
+
+## 状态追踪
+
+`agents/blueprint-absorber/STATUS.md` 记录哪些 hint 文件已吸收（Absorbed）、哪些待处理（Pending）。
+成功吸收后 agent 自动更新此文件。

--- a/agents/blueprint-absorber/run.sh
+++ b/agents/blueprint-absorber/run.sh
@@ -124,16 +124,35 @@ Instructions:
    - If the file was listed under '## Pending', remove it from there.
 8. Report what changed and whether validation passed." \
         2>>"$stderr_dest" | python3 -u -c "
-import sys, json, datetime
+import sys, json, datetime, urllib.request, os
 
 VERBOSE = '$VERBOSE_LOGS' == 'true'
 RAW = open('$RAW_FILE', 'a') if VERBOSE else None
 JSONL = open('$JSONL_FILE', 'a')
 
+_INGEST_URL   = os.getenv('KIP_INGEST_URL', '')
+_INGEST_TOKEN = os.getenv('KIP_INGEST_TOKEN', '')
+_AGENT        = 'blueprint-absorber'
+_RUN_ID       = 'run-$RUN_TS'
+_HINT_FILE    = '$HINT_FILE'
+
+def ingest(row):
+    if not _INGEST_URL:
+        return
+    payload = json.dumps({'agent': _AGENT, 'runId': _RUN_ID, 'hintFile': _HINT_FILE, 'row': row}).encode()
+    req = urllib.request.Request(_INGEST_URL, data=payload,
+        headers={'Content-Type': 'application/json', 'Authorization': 'Bearer ' + _INGEST_TOKEN},
+        method='POST')
+    try:
+        urllib.request.urlopen(req, timeout=3)
+    except Exception:
+        pass
+
 def emit(event_type, **fields):
     row = {'ts': datetime.datetime.now(datetime.timezone.utc).isoformat().replace('+00:00', 'Z'), 'event': event_type, **fields}
     JSONL.write(json.dumps(row) + '\n')
     JSONL.flush()
+    ingest(row)
 
 last_result = ''
 

--- a/homepage/index.html
+++ b/homepage/index.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>On the Last Kervaire Invariant Problem</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 2rem;
+      color: #333;
+      line-height: 1.6;
+    }
+    h1 { color: #159957; margin-bottom: 0.3rem; }
+    .subtitle { color: #606c71; font-size: 1.1rem; margin-bottom: 1.5rem; }
+    .description { margin-bottom: 1.5rem; font-size: 1.05rem; }
+
+    /* progress */
+    .progress-card {
+      background: #f6f8fa;
+      border-radius: 8px;
+      padding: 1rem 1.4rem;
+      margin-bottom: 2rem;
+      border: 1px solid #e1e4e8;
+    }
+    .progress-label {
+      font-size: 0.85rem;
+      color: #606c71;
+      margin-bottom: 0.5rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .progress-bar-wrap {
+      background: #e1e4e8;
+      border-radius: 4px;
+      height: 10px;
+      overflow: hidden;
+      margin-bottom: 0.5rem;
+    }
+    .progress-segments { display: flex; height: 100%; }
+    .seg { height: 100%; transition: width 0.4s; }
+    .seg-proved    { background: #28a745; }
+    .seg-aligned   { background: #e36209; }
+    .seg-bound     { background: #0366d6; }
+    .seg-nl        { background: #6f42c1; }
+    .seg-drafted   { background: #c9ccd1; }
+    .progress-stats {
+      display: flex; gap: 1rem; flex-wrap: wrap;
+      font-size: 0.85rem; color: #444;
+    }
+    .stat { display: flex; align-items: center; gap: 0.3rem; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+
+    /* links */
+    .links { list-style: none; padding: 0; }
+    .links li {
+      margin: 0.8rem 0;
+      padding: 0.8rem 1.2rem;
+      background: #f6f8fa;
+      border-radius: 6px;
+      border-left: 4px solid #159957;
+    }
+    .links li.dashboard { border-left-color: #0366d6; }
+    .links a {
+      color: #159957;
+      text-decoration: none;
+      font-weight: 600;
+      font-size: 1.05rem;
+    }
+    .links li.dashboard a { color: #0366d6; }
+    .links a:hover { text-decoration: underline; }
+    .links .desc { color: #606c71; font-size: 0.9rem; margin-top: 0.2rem; }
+  </style>
+</head>
+<body>
+  <h1>On the Last Kervaire Invariant Problem</h1>
+  <p class="subtitle">by Weinan Lin, Guozhen Wang, and Zhouli Xu</p>
+  <p class="description">
+    A Lean 4 formalization of the paper <em>On the Last Kervaire Invariant Problem</em>,
+    which proves that framed manifolds of Kervaire invariant one exist in dimension 126.
+  </p>
+
+  <div class="progress-card">
+    <div class="progress-label">Formalization progress</div>
+    <div class="progress-bar-wrap">
+      <div class="progress-segments" id="bar">
+        <div class="seg seg-proved"  id="seg-proved"  style="width:0%"></div>
+        <div class="seg seg-aligned" id="seg-aligned" style="width:0%"></div>
+        <div class="seg seg-bound"   id="seg-bound"   style="width:0%"></div>
+        <div class="seg seg-nl"      id="seg-nl"      style="width:0%"></div>
+        <div class="seg seg-drafted" id="seg-drafted" style="width:0%"></div>
+      </div>
+    </div>
+    <div class="progress-stats" id="stats">
+      <span style="color:#aaa;font-size:0.85rem">Loading…</span>
+    </div>
+  </div>
+
+  <ul class="links">
+    <li class="dashboard">
+      <a href="/dashboard/">Dashboard</a>
+      <div class="desc">Formalization progress · dependency DAG · agent logs · review actions</div>
+    </li>
+    <li>
+      <a href="/index.html">Blueprint</a>
+      <div class="desc">Interactive blueprint with dependency graph and review system</div>
+    </li>
+    <li>
+      <a href="https://surenny.github.io/KIP/blueprint.pdf" target="_blank">Blueprint as PDF</a>
+      <div class="desc">Downloadable PDF version of the blueprint</div>
+    </li>
+    <li>
+      <a href="https://surenny.github.io/KIP/docs/" target="_blank">Lean API Docs</a>
+      <div class="desc">Auto-generated documentation for the Lean formalization</div>
+    </li>
+    <li>
+      <a href="https://github.com/surenny/KIP" target="_blank">Source Code</a>
+      <div class="desc">GitHub repository</div>
+    </li>
+  </ul>
+
+  <script>
+    const PHASES = [
+      { key: 'proved',      label: 'Proved',      cls: 'seg-proved',  dot: '#28a745' },
+      { key: 'aligned',     label: 'Aligned',     cls: 'seg-aligned', dot: '#e36209' },
+      { key: 'bound',       label: 'Bound',       cls: 'seg-bound',   dot: '#0366d6' },
+      { key: 'nl_reviewed', label: 'NL reviewed', cls: 'seg-nl',      dot: '#6f42c1' },
+      { key: 'drafted',     label: 'Drafted',     cls: 'seg-drafted', dot: '#c9ccd1' },
+    ];
+
+    fetch('/dashboard/api/state/health')
+      .then(r => r.json())
+      .then(data => {
+        const phases = data.phases || {};
+        const total  = data.counts?.nodes || 1;
+
+        PHASES.forEach(p => {
+          const n = phases[p.key] || 0;
+          const seg = document.getElementById('seg-' + (p.key === 'nl_reviewed' ? 'nl' : p.key));
+          if (seg) seg.style.width = (n / total * 100).toFixed(1) + '%';
+        });
+
+        const statsEl = document.getElementById('stats');
+        statsEl.innerHTML = PHASES.map(p => {
+          const n = phases[p.key] || 0;
+          return `<span class="stat"><span class="dot" style="background:${p.dot}"></span>${p.label}: <strong>${n}</strong></span>`;
+        }).join('') + `<span class="stat" style="margin-left:auto;color:#888">/ ${total} nodes</span>`;
+      })
+      .catch(() => {
+        document.getElementById('stats').innerHTML =
+          '<span style="color:#aaa;font-size:0.85rem">Progress unavailable</span>';
+      });
+  </script>
+</body>
+</html>

--- a/ui/server/src/index.ts
+++ b/ui/server/src/index.ts
@@ -11,6 +11,7 @@ import { register as registerAgents } from './routes/agents.js';
 import { register as registerLogs } from './routes/logs.js';
 import { register as registerSummary } from './routes/summary.js';
 import { register as registerNodes } from './routes/nodes.js';
+import { register as registerIngest } from './routes/ingest.js';
 
 export interface ProjectPaths {
   projectPath: string;
@@ -64,6 +65,7 @@ export async function createServer(options: { projectPath: string; port: number 
   registerLogs(fastify, paths);
   registerSummary(fastify, paths);
   registerNodes(fastify, paths);
+  registerIngest(fastify, paths);
 
   await fastify.listen({ port, host: '0.0.0.0' });
   return fastify;

--- a/ui/server/src/routes/ingest.ts
+++ b/ui/server/src/routes/ingest.ts
@@ -19,7 +19,10 @@ export function register(fastify: FastifyInstance, paths: ProjectPaths) {
       }
     }
 
-    const { agent, runId, hintFile, row } = req.body as Record<string, unknown>;
+    const body = req.body as Record<string, unknown> | undefined;
+    if (!body) return reply.code(400).send({ error: 'missing JSON body' });
+
+    const { agent, runId, hintFile, row } = body;
 
     if (!safeSeg(agent) || !safeSeg(runId)) {
       return reply.code(400).send({ error: 'invalid agent or runId' });

--- a/ui/server/src/routes/ingest.ts
+++ b/ui/server/src/routes/ingest.ts
@@ -1,0 +1,72 @@
+import fs from 'fs';
+import path from 'path';
+import type { FastifyInstance } from 'fastify';
+import type { ProjectPaths } from '../index.js';
+
+const TOKEN = process.env.KIP_INGEST_TOKEN ?? '';
+
+// agent name and runId must be safe path segments
+function safeSeg(s: unknown): s is string {
+  return typeof s === 'string' && /^[\w.\-:]+$/.test(s) && !s.includes('..');
+}
+
+export function register(fastify: FastifyInstance, paths: ProjectPaths) {
+  fastify.post('/api/ingest', async (req, reply) => {
+    if (TOKEN) {
+      const auth = (req.headers.authorization ?? '') as string;
+      if (auth !== `Bearer ${TOKEN}`) {
+        return reply.code(401).send({ error: 'unauthorized' });
+      }
+    }
+
+    const { agent, runId, hintFile, row } = req.body as Record<string, unknown>;
+
+    if (!safeSeg(agent) || !safeSeg(runId)) {
+      return reply.code(400).send({ error: 'invalid agent or runId' });
+    }
+
+    const runDir = path.resolve(paths.agentsPath, agent, 'logs', runId);
+    if (!runDir.startsWith(paths.agentsPath + path.sep)) {
+      return reply.code(400).send({ error: 'path outside agents directory' });
+    }
+
+    fs.mkdirSync(runDir, { recursive: true });
+
+    const metaFile = path.join(runDir, 'meta.json');
+    const jsonlFile = path.join(runDir, 'absorber.jsonl');
+
+    // Write meta.json on the first event for this run
+    if (!fs.existsSync(metaFile)) {
+      const meta = {
+        agent,
+        hint_file: typeof hintFile === 'string' ? hintFile : null,
+        startedAt: (row as Record<string, unknown>)?.ts ?? new Date().toISOString(),
+        completedAt: null,
+        status: 'running',
+        model: null,
+      };
+      fs.writeFileSync(metaFile, JSON.stringify(meta, null, 2));
+    }
+
+    // Update meta on session_end
+    if ((row as Record<string, unknown>)?.event === 'session_end') {
+      try {
+        const meta = JSON.parse(fs.readFileSync(metaFile, 'utf-8'));
+        meta.completedAt = (row as Record<string, unknown>).ts ?? new Date().toISOString();
+        meta.status = 'done';
+        const usage = (row as Record<string, unknown>).model_usage as Record<string, unknown> | undefined;
+        if (usage) {
+          const first = Object.keys(usage)[0];
+          if (first) meta.model = first;
+        }
+        fs.writeFileSync(metaFile, JSON.stringify(meta, null, 2));
+      } catch { /* ignore */ }
+    }
+
+    // Append event row to JSONL — fs.watch in logs.ts picks this up automatically
+    // and broadcasts to any connected WebSocket clients watching this file
+    fs.appendFileSync(jsonlFile, JSON.stringify(row) + '\n');
+
+    return reply.code(204).send();
+  });
+}


### PR DESCRIPTION
## 问题

`homepage/` 目录只在 `feat/unify-annotation-system` 分支上，合并 PR #14 时没有带进 main，导致 `kip.opensii.ai/` 返回 404。

## 改动

恢复 `homepage/index.html`，在原有基础上做了两处改进：

**1. 新增 Dashboard 入口**
- 链接到 `/dashboard/`，蓝色边框区分于其他条目

**2. 实时进度条**
- 页面加载时从 `/dashboard/api/state/health` 拉取节点数据
- 按 proved / aligned / bound / nl\_reviewed / drafted 五个阶段分色显示进度条
- API 不可达时静默降级，不影响页面其余内容

## 验证

`https://kip.opensii.ai/` 现已恢复正常，进度条数据实时显示。