### PR TITLE
refactor: rename .kip/ runtime dir to .dashboard/ + .orchestrator/ (AUT-52)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,7 @@ ui/server/node_modules/
 ui/server/dist/
 ui/client/node_modules/
 ui/client/dist/
+/.dashboard/
+/.orchestrator/
+# legacy, see AUT-52; safe to `rm -rf .kip/` locally
 /.kip/

--- a/tools/kip-state/index.py
+++ b/tools/kip-state/index.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-r"""Build .kip/state.db from project sources.
+r"""Build .dashboard/state.db from project sources.
 
 Inputs:
   blueprint/status.yaml          - node lifecycle flags, comments
@@ -7,7 +7,7 @@ Inputs:
   KIP/**/*.lean                  - declarations + sorry counts (per fully-qualified name)
   agents/*/logs/run-*/           - agent runs (meta.json + .jsonl with session_end)
 
-Output: .kip/state.db (SQLite, gitignored, safe to drop)
+Output: .dashboard/state.db (SQLite, gitignored, safe to drop)
 
 Usage:
   python tools/kip-state/index.py [--project PATH] [--db PATH]
@@ -300,12 +300,12 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--project", type=Path, default=Path.cwd(),
                     help="KIP project root (default: cwd)")
     ap.add_argument("--db", type=Path, default=None,
-                    help="Output SQLite path (default: <project>/.kip/state.db)")
+                    help="Output SQLite path (default: <project>/.dashboard/state.db)")
     ap.add_argument("--quiet", action="store_true")
     args = ap.parse_args(argv)
 
     project: Path = args.project.resolve()
-    db_path: Path = args.db or (project / ".kip" / "state.db")
+    db_path: Path = args.db or (project / ".dashboard" / "state.db")
     db_path.parent.mkdir(parents=True, exist_ok=True)
 
     log = (lambda *a, **k: None) if args.quiet else (lambda *a, **k: print(*a, **k, file=sys.stderr))

--- a/ui/client/src/views/Overview.tsx
+++ b/ui/client/src/views/Overview.tsx
@@ -32,7 +32,7 @@ export default function Overview() {
       <div className={styles.root}>
         <h2 className={styles.title}>State index unavailable</h2>
         <div className={styles.empty}>
-          {health?.error || 'Run python tools/kip-state/index.py to build .kip/state.db.'}
+          {health?.error || 'Run python tools/kip-state/index.py to build .dashboard/state.db.'}
         </div>
       </div>
     );

--- a/ui/server/src/routes/nodes.ts
+++ b/ui/server/src/routes/nodes.ts
@@ -196,7 +196,7 @@ function getChapterOrder(projectPath: string): string[] {
 }
 
 function openDb(projectPath: string): Database.Database | null {
-  const candidate = path.join(projectPath, '.kip', 'state.db');
+  const candidate = path.join(projectPath, '.dashboard', 'state.db');
   if (!fs.existsSync(candidate)) return null;
   const stat = fs.statSync(candidate);
   if (dbInstance && dbPath === candidate && dbMtime === stat.mtimeMs) {
@@ -214,7 +214,7 @@ function openDb(projectPath: string): Database.Database | null {
 // Separate write handle, used only by review actions. Each call opens / closes
 // to avoid juggling cache invalidation alongside the readonly handle above.
 function openDbForWrite(projectPath: string): Database.Database | null {
-  const candidate = path.join(projectPath, '.kip', 'state.db');
+  const candidate = path.join(projectPath, '.dashboard', 'state.db');
   if (!fs.existsSync(candidate)) return null;
   return new Database(candidate, { readonly: false, fileMustExist: true });
 }
@@ -334,7 +334,7 @@ export function register(fastify: FastifyInstance, paths: ProjectPaths) {
     if (!db) {
       return {
         ok: false,
-        error: 'No .kip/state.db found. Run: python tools/kip-state/index.py',
+        error: 'No .dashboard/state.db found. Run: python tools/kip-state/index.py',
       };
     }
     const meta = db.prepare("SELECT key, value FROM meta").all() as { key: string; value: string }[];
@@ -557,7 +557,7 @@ export function register(fastify: FastifyInstance, paths: ProjectPaths) {
   //   approve_nl         drafted          → nl_reviewed
   //   confirm_alignment  nl_reviewed+bound → aligned
   // Source of truth is blueprint/status.yaml (what tools/kip-state/index.py
-  // reads on rebuild). We mirror the change into .kip/state.db so the dashboard
+  // reads on rebuild). We mirror the change into .dashboard/state.db so the dashboard
   // reflects it immediately without re-running the indexer.
   fastify.post<{
     Params: { id: string };


### PR DESCRIPTION
## Summary

`.kip/` confused the project namespace (Kervaire Invariant Problem) with a tool-layer runtime directory. This PR splits the runtime artifacts into two semantic dirs:

- **`.dashboard/state.db`** — UI state index (consumer: `ui/server`, `tools/kip-state`)
- **`.orchestrator/`** — orchestrator runtime artifacts (`cycles/`, `audit/`, incoming with the upcoming plan-prover-review loop, see `ORCHESTRATOR_DESIGN_HANDOFF.md`)

Why two dirs instead of one: dashboard and orchestrator are independent consumers and should evolve independently.

Files changed (4):
- `.gitignore` — replace `/.kip/` with `/.dashboard/` + `/.orchestrator/`; legacy `/.kip/` retained as transition aid
- `tools/kip-state/index.py` — default output path + docstring
- `ui/server/src/routes/nodes.ts` — read paths + error message + comment
- `ui/client/src/views/Overview.tsx` — error toast text

Dockerfiles + compose: no `.kip/` hardcoding found, untouched.

Linear: AUT-52

## Migration

After pulling this PR, rebuild the dashboard index:

\`\`\`bash
python tools/kip-state/index.py     # writes to .dashboard/state.db
rm -rf .kip/                        # safe: state.db is derived
\`\`\`

The legacy \`/.kip/\` ignore rule keeps your local \`.kip/\` from showing in \`git status\`; remove it in a follow-up cleanup PR after the team has migrated.

## Test plan

- [x] \`python tools/kip-state/index.py\` writes to \`.dashboard/state.db\` (verified: 239 nodes / 321 edges / 299 lean decls / 7 agent runs)
- [x] \`npx tsc --noEmit\` in \`ui/server\` passes
- [ ] Dashboard reads \`.dashboard/state.db\` end-to-end (reviewer to verify in their dev setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)